### PR TITLE
Fix comments report button

### DIFF
--- a/src/stylesheets/livefyre_widget_overrides.scss
+++ b/src/stylesheets/livefyre_widget_overrides.scss
@@ -469,6 +469,9 @@
 		}
 
 		.fyre-comment-flag-mobile-btn {
+			
+			min-width: 100px;
+			
 			&:before {
 				content: "Report";
 				font-size: 13px;


### PR DESCRIPTION
Set a `min-width` on `.fyre-comment-flag-mobile-btn`.

The `.fyre-comment-flag-mobile-btn` class only appears on mobile devices, regardless of viewport width (mobile devices appear to be being served different markup)

The desktop site link actually contains the text 'report', so we set the width to `auto` so it is displayed at the correct width to contain its contents.

On mobile, we override the styles of this button using the `:before` pseudoelement so that says the word 'Report' rather than just being an icon (which it presumably is otherwise).

Because on mobile there's no real text in the button element itself, width auto shrinks it down too small. Setting a min-width on just the `.fyre-comment-flag-mobile-btn` class resolves this issue without affecting the desktop site

Before:
![screen shot 2016-10-28 at 16 49 01](https://cloud.githubusercontent.com/assets/4622378/19812979/91bb9626-9d2f-11e6-8c92-f42f7778820c.png)

After:
![screen shot 2016-10-28 at 16 49 06](https://cloud.githubusercontent.com/assets/4622378/19812987/9d145b70-9d2f-11e6-8f9e-55c3e5fbac57.png)
