### PR TITLE
increase button contrast

### DIFF
--- a/src/stylesheets/livefyre_widget_overrides.scss
+++ b/src/stylesheets/livefyre_widget_overrides.scss
@@ -956,9 +956,9 @@
 					@include oCommentsBorderRadiusClear;
 
 					border-right: 0;
-					background-color: #549ccf;
-					background-image: linear-gradient(#549ccf, #4781aa);
-					filter: progid:DXImageTransform.Microsoft.gradient(GradientType=0, startColorstr=#549ccf,  endColorstr=#4781aa);
+					background-color: #2c6d9c;
+					background-image: linear-gradient(#2c6d9c, #255b82);
+					filter: progid:DXImageTransform.Microsoft.gradient(GradientType=0, startColorstr=#2c6d9c,  endColorstr=#255b82);
 				}
 
 				> div.fyre-button-right.fyre-post-button .fyre-button-right-outer-box {
@@ -1352,7 +1352,7 @@ body {
 	.fyre-hovercard-button:hover {
 		@include oCommentsGradientClear;
 
-		background-color: #549ccf;
+		background-color: #2c6d9c;
 		color: oColorsGetPaletteColor('white');
 	}
 


### PR DESCRIPTION
The submit button was flagged for having low color contrast in our recent a11y audit

<img width="155" alt="screen shot 2016-12-11 at 08 32 51" src="https://cloud.githubusercontent.com/assets/3425322/21079040/76595ad4-bf7c-11e6-8c3a-e9e437df7131.png">
<img width="498" alt="screen shot 2016-12-11 at 08 23 49" src="https://cloud.githubusercontent.com/assets/3425322/21079035/548c7544-bf7c-11e6-92f7-dc448ca4f102.png">

We've replaced the two blues that make up the background of this button with slightly darker versions to bump contrast to 4.5:1 for both against the white text

<img width="135" alt="screen shot 2016-12-11 at 08 56 47" src="https://cloud.githubusercontent.com/assets/3425322/21079140/d362eb16-bf7f-11e6-883e-1557d3a6a47b.png">
