### PR TITLE
padlock was renamed to lock in fticon-v1

### DIFF
--- a/src/stylesheets/livefyre_widget_overrides.scss
+++ b/src/stylesheets/livefyre_widget_overrides.scss
@@ -1061,7 +1061,7 @@
 			height: auto;
 
 			.fyre-editor-locked {
-				@include oIconsGetIcon('padlock', oColorsGetPaletteColor("black-70"), 20, $iconset-version: 1);
+				@include oIconsGetIcon('lock', oColorsGetPaletteColor("black-70"), 20, $iconset-version: 1);
 
 				vertical-align: inherit;
 				margin-right: 0;


### PR DESCRIPTION
Reference to the renaming -- https://github.com/Financial-Times/fticons/blob/master/README.mdd#renamed