### PR TITLE
More defensive access to localStorage

### DIFF
--- a/src/javascripts/utils.js
+++ b/src/javascripts/utils.js
@@ -12,7 +12,7 @@ exports.emptyLivefyreActionQueue = function () {
 };
 
 exports.isLivefyreActionQueuePresent = function () {
-	return !!oCommentUtilities.storageWrapper.localStorage.getItem(QUEUE_KEY);
+	return Boolean(oCommentUtilities.storageWrapper.localStorage.getItem(QUEUE_KEY));
 };
 
 /**

--- a/src/javascripts/utils.js
+++ b/src/javascripts/utils.js
@@ -1,24 +1,18 @@
 const oCommentUtilities = require('o-comment-utilities');
 
+const QUEUE_KEY = 'fyre-action-queue';
+
 /**
  * Livefyre creates a queue in localStorage when a user posts a comment without being logged in.
  * This method clears the queue.
  * @return {undefined}
  */
 exports.emptyLivefyreActionQueue = function () {
-	if (typeof Storage !== 'undefined') {
-		oCommentUtilities.storageWrapper.localStorage.removeItem('fyre-action-queue');
-	}
+	oCommentUtilities.storageWrapper.localStorage.removeItem(QUEUE_KEY);
 };
 
 exports.isLivefyreActionQueuePresent = function () {
-	if (typeof Storage !== 'undefined') {
-		if (oCommentUtilities.storageWrapper.localStorage.getItem('fyre-action-queue')) {
-			return true;
-		}
-	}
-
-	return false;
+	return !!oCommentUtilities.storageWrapper.localStorage.getItem(QUEUE_KEY);
 };
 
 /**

--- a/src/javascripts/utils.js
+++ b/src/javascripts/utils.js
@@ -13,7 +13,7 @@ exports.emptyLivefyreActionQueue = function () {
 
 exports.isLivefyreActionQueuePresent = function () {
 	if (typeof Storage !== 'undefined') {
-		if (localStorage.getItem('fyre-action-queue')) {
+		if (oCommentUtilities.storageWrapper.localStorage.getItem('fyre-action-queue')) {
 			return true;
 		}
 	}


### PR DESCRIPTION
It seems with Android webview, `Storage` is defined, but `localStorage` is `null`, so errors are being thrown: https://sentry.io/nextftcom/ft-next-article/issues/579610508

This PR makes more use of `o-comment-utilities` [storage wrapper](https://github.com/Financial-Times/o-comment-utilities/blob/master/src/javascripts/storageWrapper/StorageWrapper.js#L6) to defend against this scenario.
