### PR TITLE
Switch dom-delegate for ftdomdelegate.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,5 @@
+## Migration
+
+### Migrating from v4 to v5
+
+The dependency `dom-delegate` has been replaced by `ftdomdelegate`. If your project depends on `dom-delegate`, switch to `ftdomdelegate@^3.0.0` instead -- their api is the same, but `dom-delegate` is now deprecated. Ensure your project builds without conflicts.

--- a/README.md
+++ b/README.md
@@ -457,3 +457,13 @@ Works in accordance with our [support policy](https://docs.google.com/a/ft.com/d
 
 ## <div id="core"></div> Core/Enhanced Experience
 Only the enhanced experience offers any kind of commenting functionality. Core functionality will be added in due course.
+
+## Migration
+
+State | Major Version | Last Minor Release | Migration guide |
+:---: | :---: | :---: | :---:
+✨ active | 5 | N/A | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
+⚠ maintained | 4 | 4.2.0 | - |
+╳ deprecated | 3 | 3.5.0 | - |
+╳ deprecated | 2 | 2.5.0 | - |
+╳ deprecated | 1 | 1.0.10 | - |

--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "o-colors": "^4.0.0",
     "o-assets": ">=2.0.0 <4",
     "o-icons": ">=4.0.0 <6",
-    "dom-delegate": "^2.1.0"
+    "ftdomdelegate": ">=2.2.0 <4.0.0"
   },
   "ignore": [
     "node_modules",
@@ -22,9 +22,5 @@
     "package.json",
     ".editorconfig",
     ".jshintrc"
-  ],
-  "resolutions": {
-    "o-fonts": "^3.0.0",
-    "o-colors": "^4.0.1"
-  }
+  ]
 }


### PR DESCRIPTION
All other maintained components use ftdomdelegate, which is the
same except for the name. We don't want two versions included.

We can do this now @i-like-robots has removed the  "dom-delegate" 
name from ftdomdelegate and published to npm:
https://github.com/Financial-Times/ftdomdelegate/pull/93

_I've also removed resolutions: why is that there!?_

~I think it's acceptable to treat as a patch as the chance of conflict is 
extremely low. Thoughts?~ I take that back. This will have to be a major.