### PR TITLE
Add a NPM prerelease tag for beta releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,14 @@ jobs:
       - run: npx occ ${CIRCLE_TAG##v}
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > $HOME/.npmrc
       - run: npm publish --access public 
+  publish_prerelease_to_npm:
+    docker:
+      - image: circleci/node:10
+    steps:
+      - checkout
+      - run: npx occ ${CIRCLE_TAG##v}
+      - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > $HOME/.npmrc
+      - run: npm publish --access public --tag=pre-release
 workflows:
   version: 2
   test:
@@ -31,6 +39,12 @@ workflows:
       - publish_to_npm:
           filters:
             tags:
-              only: /^v.*/
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+            branches:
+              ignore: /.*/
+      - publish_prerelease_to_npm:
+          filters:
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+-/
             branches:
               ignore: /.*/


### PR DESCRIPTION
This will allow prereleases to be published under the correct prerelease [dist-tag](https://docs.npmjs.com/cli/dist-tag)

Without this NPM will publish the changes as latest. See
https://github.com/npm/npm/issues/13248 for more info.

Prereleases are matched with the `^v[0-9]+\.[0-9]+\.[0-9]+-` regex which
will match any release with a pattern like `v1.0.0-beta.1`

Latest releases are matched with the `^v[0-9]+\.[0-9]+\.[0-9]+$` regex
which is stricter and forces the patch number to be the final character.
This will match release like `v12.0.3`