### PR TITLE
Update regex to capture beta releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - checkout
       - run: npx occ ${CIRCLE_TAG##v}
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > $HOME/.npmrc
-      - run: npm publish --access public 
+      - run: npm publish --access public
   publish_prerelease_to_npm:
     docker:
       - image: circleci/node:10
@@ -45,6 +45,6 @@ workflows:
       - publish_prerelease_to_npm:
           filters:
             tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+-/
+              only: /^v?\d+\.\d+\.\d+(?:-beta\.\d+)?$/
             branches:
               ignore: /.*/


### PR DESCRIPTION
The previous `publish_prerelease_to_npm` regex did not correctly capture beta releases, so I've updated it so it will.