### PR TITLE
Add a toxic error event and document deprecated events

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -19,17 +19,17 @@ The table below shows the mapping of old events to new.
 | ---------------------- | --------------------------- |
 | error.init             | Not mapped yet              |
 | error.widget           | Not mapped yet              |
-| error.livefyreJs       | Not mapped yet              |
-| widget.timeout         | Not mapped yet              |
+| error.livefyreJs       | Deprecated                  |
 | data.init              | Not mapped yet              |
 | data.auth              | Not mapped yet              |
-| widget.ready           | Not mapped yet              |
-| widget.load            | Not mapped yet              |
+| widget.timeout         | Not mapped yet              |
+| widget.ready           | Deprecation candidate       |
+| widget.load            | Deprecation candidate       |
 | widget.renderComplete  | component.render.successful |
 | tracking.postComment   | comment.posted.successful   |
 | tracking.likeComment   | comment.liked.successful    |
-| tracking.shareComment  | Not mapped yet              |
-| tracking.socialMention | Not mapped yet              |
+| tracking.shareComment  | Deprecation candidate       |
+| tracking.socialMention | Deprecated                  |
 | auth.login             | auth.login.successful       |
 | auth.loginRequired     | auth.login.required         |
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ These events are anything to do with the component itself.
 These events are anything to do with comment interactions.
 
 - **comment.posted.successful** - Emitted when a users has successfully left a comment
+- **comment.posted.toxic** - Emitted when a comment has been flagged as above our acceptable level of toxicity by the automated toxic moderation.
 - **comment.liked.successful** - Emitted when a users has liked a comment
 
 ##### Auth

--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -1,21 +1,22 @@
-const validEvents = [
-	'component.render.successful',
-	'comment.posted.successful',
-	'comment.liked.successful',
-	'actions.comment.liked',
-	'auth.login.successful',
-	'auth.login.required'
-];
-
 const coralMap = new Map([
+	['query.CoralEmbedStream_Embed.loading', 'component.render.loading'],
 	['query.CoralEmbedStream_Embed.ready', 'component.render.successful'],
 	['mutation.PostComment.success', 'comment.posted.successful'],
+	['mutation.EditComment.success', 'comment.edited.successful'],
 	['mutation.CreateLikeAction.success', 'comment.liked.successful'],
 	['action.TALK_FRAMEWORK_CHECK_LOGIN_SUCCESS', 'auth.login.successful'],
 	['action.SHOW_SIGNIN_DIALOG', 'auth.login.required']
 ]);
 
+const errorMap = new Map([
+	['COMMENT_IS_TOXIC', 'comment.posted.toxic']
+]);
+
+const validEvents = []
+	.concat(Array.from(coralMap.values()), Array.from(errorMap.values()));
+
 export {
 	validEvents,
-	coralMap
+	coralMap,
+	errorMap
 };

--- a/test/oComments.test.js
+++ b/test/oComments.test.js
@@ -168,7 +168,66 @@ describe("OComments", () => {
 						name: 'action.SHOW_SIGNIN_DIALOG'
 					}
 				}));
-				proclaim.isTrue(beenCalled);
+				proclaim.isTrue(eventWasEmitted);
+			});
+
+			describe("when the payload contains an error", () => {
+				it("maps the `COMMENT_IS_TOXIC` error event", () => {
+					comments.on('comment.posted.toxic', () => {
+						eventWasEmitted = true;
+					});
+
+					window.dispatchEvent(new CustomEvent('talkEvent', {
+						detail: {
+							data: {
+								error: {
+									errors: [
+										{
+											translation_key: 'COMMENT_IS_TOXIC'
+										}
+									]
+								}
+							}
+						}
+					}));
+
+					proclaim.isTrue(eventWasEmitted);
+				});
+
+			});
+
+			describe("when the payload contains an error and a valid event", () => {
+				it("maps the `COMMENT_IS_TOXIC` error event", () => {
+					let errorCalled = false;
+					let eventCalled = false;
+
+					comments.on('comment.posted.toxic', () => {
+						errorCalled = true;
+					});
+
+					comments.on('comment.edited.successful', () => {
+						eventCalled = true;
+					});
+
+					window.dispatchEvent(new CustomEvent('talkEvent', {
+						detail: {
+							name: 'mutation.EditComment.success',
+							data: {
+								error: {
+									errors: [
+										{
+											translation_key: 'COMMENT_IS_TOXIC'
+										}
+									]
+								}
+							}
+						}
+					}));
+
+					proclaim.isTrue(errorCalled);
+					proclaim.isTrue(eventCalled);
+				});
+
 			});
 		});
 	});

--- a/test/oComments.test.js
+++ b/test/oComments.test.js
@@ -63,52 +63,51 @@ describe("OComments", () => {
 	});
 
 	describe(".on", () => {
+		let comments;
+		let eventWasEmitted;
+
 		beforeEach(() => {
 			fixtures.htmlCode();
+			comments = OComments.init('#element');
+			eventWasEmitted = false;
 		});
 
 		afterEach(() => {
 			fixtures.reset();
+			eventWasEmitted = false;
+			comments = false;
 		});
 
 		it("is a function", () => {
-			const comments = OComments.init('#element');
 			proclaim.equal(typeof comments.on, 'function');
 		});
 
 		it("throws a error if it's missing a parameter", () => {
-			const comments = OComments.init('#element');
 			proclaim.throws(() => comments.on('component.render.successful'), '.on requires both the `event` & `callback` parameters');
 		});
 
 		it("throws a error if the event name isn't valid", () => {
-			const comments = OComments.init('#element');
 			proclaim.throws(() => comments.on('not.real', () => {}), 'not.real is not a valid event');
 		});
 
 		it("throws a type error if the callback parameter isn't a function", () => {
-			const comments = OComments.init('#element');
 			proclaim.throws(() => comments.on('component.render.successful', 'Not a function'),'The callback must be a function');
 		});
 
 		it("calls the callback when the event is omitted", () => {
-			let beenCalled = false;
-			const comments = OComments.init('#element');
 			comments.on('component.render.successful', () => {
-				beenCalled = true;
+				eventWasEmitted = true;
 			});
 
 			document.dispatchEvent(new CustomEvent('component.render.successful'));
 
-			proclaim.isTrue(beenCalled);
+			proclaim.isTrue(eventWasEmitted);
 		});
 
 		describe("when Coral Talk events are omittd", () => {
 			it("maps the `query.CoralEmbedStream_Embed.ready` event", () => {
-				let beenCalled = false;
-				const comments = OComments.init('#element');
 				comments.on('component.render.successful', () => {
-					beenCalled = true;
+					eventWasEmitted = true;
 				});
 
 				window.dispatchEvent(new CustomEvent('talkEvent', {
@@ -117,14 +116,12 @@ describe("OComments", () => {
 					}
 				}));
 
-				proclaim.isTrue(beenCalled);
+				proclaim.isTrue(eventWasEmitted);
 			});
 
 			it("maps the `mutation.PostComment.success` event", () => {
-				let beenCalled = false;
-				const comments = OComments.init('#element');
 				comments.on('comment.posted.successful', () => {
-					beenCalled = true;
+					eventWasEmitted = true;
 				});
 
 				window.dispatchEvent(new CustomEvent('talkEvent', {
@@ -132,14 +129,12 @@ describe("OComments", () => {
 						name: 'mutation.PostComment.success'
 					}
 				}));
-				proclaim.isTrue(beenCalled);
+				proclaim.isTrue(eventWasEmitted);
 			});
 
 			it("maps the `mutation.CreateLikeAction.success` event", () => {
-				let beenCalled = false;
-				const comments = OComments.init('#element');
 				comments.on('comment.liked.successful', () => {
-					beenCalled = true;
+					eventWasEmitted = true;
 				});
 
 				window.dispatchEvent(new CustomEvent('talkEvent', {
@@ -147,14 +142,12 @@ describe("OComments", () => {
 						name: 'mutation.CreateLikeAction.success'
 					}
 				}));
-				proclaim.isTrue(beenCalled);
+				proclaim.isTrue(eventWasEmitted);
 			});
 
 			it("maps the `action.TALK_FRAMEWORK_CHECK_LOGIN_SUCCESS` event", () => {
-				let beenCalled = false;
-				const comments = OComments.init('#element');
 				comments.on('auth.login.successful', () => {
-					beenCalled = true;
+					eventWasEmitted = true;
 				});
 
 				window.dispatchEvent(new CustomEvent('talkEvent', {
@@ -162,14 +155,12 @@ describe("OComments", () => {
 						name: 'action.TALK_FRAMEWORK_CHECK_LOGIN_SUCCESS'
 					}
 				}));
-				proclaim.isTrue(beenCalled);
+				proclaim.isTrue(eventWasEmitted);
 			});
 
 			it("maps the `action.SHOW_SIGNIN_DIALOG` event", () => {
-				let beenCalled = false;
-				const comments = OComments.init('#element');
 				comments.on('auth.login.required', () => {
-					beenCalled = true;
+					eventWasEmitted = true;
 				});
 
 				window.dispatchEvent(new CustomEvent('talkEvent', {


### PR DESCRIPTION
Document deprecated events and events that are candidates for deprecation. See commit [f7a4870](https://github.com/Financial-Times/o-comments/commit/f7a4870b842f873238e7b98273fa7f171e4f157e) for details on why.

Also introduces a new event for when a comment is posted that doesn't pass the toxic automated moderation.

