### PR TITLE
Do not throw when no jwt token is received

### DIFF
--- a/src/js/utils/auth/index.js
+++ b/src/js/utils/auth/index.js
@@ -1,15 +1,17 @@
 const getJsonWebToken = () => fetch('https://comments-auth.ft.com/v1/jwt/', {
 	credentials: 'include'
 }).then(response => {
-	if(response.ok) {
+	if (response.ok) {
 		return response.json();
 	}
+
+	if (response.status === 404) {
+		return { token: undefined };
+	}
+
 	throw new Error('Bad response from the authentication service');
 }).then(json => {
-	if (json.token) {
-		return json.token;
-	}
-	throw new Error('Authentication token doesn\'t exist');
+	return json.token;
 });
 
 export {

--- a/test/auth/auth.test.js
+++ b/test/auth/auth.test.js
@@ -31,6 +31,7 @@ describe("Auth", () => {
 					.then(token => proclaim.isString(token));
 			});
 		});
+
 		describe("when the comments auth service response is missing the token", () => {
 			before(() => {
 				fetchMock.mock('https://comments-auth.ft.com/v1/jwt/', {});
@@ -40,19 +41,51 @@ describe("Auth", () => {
 				fetchMock.reset();
 			});
 
-			it("throws an error", () => {
+			it("resolves with undefined", () => {
 				return getJsonWebToken()
-					.then(() => {
-						throw new Error('This should never happen, its just here to make sure the .then is never entered');
-					}).catch((error) => {
-						proclaim.equal(error.message, "Authentication token doesn\'t exist");
+					.then((token) => {
+						proclaim.equal(token, undefined);
 					});
 			});
 		});
 
-		describe("when the comments auth service responds with a bad response", () => {
+		describe("when the comments auth service response is missing the token", () => {
+			before(() => {
+				fetchMock.mock('https://comments-auth.ft.com/v1/jwt/', {token: undefined});
+			});
+
+			after(() => {
+				fetchMock.reset();
+			});
+
+			it("resolves with undefined", () => {
+				return getJsonWebToken()
+					.then((token) => {
+						proclaim.equal(token, undefined);
+					});
+			});
+		});
+
+		describe("when the comments auth service responds with 404", () => {
 			before(() => {
 				fetchMock.mock('https://comments-auth.ft.com/v1/jwt/', 404);
+			});
+
+			after(() => {
+				fetchMock.reset();
+			});
+
+			it("resolves with undefined", () => {
+				return getJsonWebToken()
+					.then((token) => {
+						proclaim.equal(token, undefined);
+					});
+			});
+		});
+
+		describe("when the comments auth service responds with a bad response other than 404", () => {
+			before(() => {
+				fetchMock.mock('https://comments-auth.ft.com/v1/jwt/', 500);
 			});
 
 			after(() => {


### PR DESCRIPTION
When there is no pseudonym found for a user, next-comments-auth-service /v1/jwt endpoint will respond with a 404 status code. In this case we still want to render the comments UI, but we don't want to allow users to comment until they define a Pseudonym.

This commit changes the behaviour of getJsonWebToken for the case when authentication service responds with 404. This will allow us to render the comments UI without a logged in user.