### PR TITLE
Handle 205 response status from authentication service

### DIFF
--- a/src/js/utils/auth/index.js
+++ b/src/js/utils/auth/index.js
@@ -1,12 +1,12 @@
 const getJsonWebToken = () => fetch('https://comments-auth.ft.com/v1/jwt/', {
 	credentials: 'include'
 }).then(response => {
-	if (response.ok) {
-		return response.json();
+	if (response.status === 404 || response.status === 205) {
+		return { token: undefined };
 	}
 
-	if (response.status === 404) {
-		return { token: undefined };
+	if (response.ok) {
+		return response.json();
 	}
 
 	throw new Error('Bad response from the authentication service');

--- a/test/auth/auth.test.js
+++ b/test/auth/auth.test.js
@@ -66,6 +66,23 @@ describe("Auth", () => {
 			});
 		});
 
+		describe("when the comments auth service responds with 205", () => {
+			before(() => {
+				fetchMock.mock('https://comments-auth.ft.com/v1/jwt/', 205);
+			});
+
+			after(() => {
+				fetchMock.reset();
+			});
+
+			it("resolves with undefined", () => {
+				return getJsonWebToken()
+					.then((token) => {
+						proclaim.equal(token, undefined);
+					});
+			});
+		});
+
 		describe("when the comments auth service responds with 404", () => {
 			before(() => {
 				fetchMock.mock('https://comments-auth.ft.com/v1/jwt/', 404);


### PR DESCRIPTION
When a user has a valid session token, but no pseudonym assigned, `comments-auth-service` will respond with 205. In that case, we want to render Coral Talk with no authentication token, so that it can display an "Enter pseudonym" textbox.