### PR TITLE
Pass user sign-in status information to Coral

### DIFF
--- a/src/js/comments.js
+++ b/src/js/comments.js
@@ -27,13 +27,14 @@ class Comments {
 	_renderComments () {
 		/*global Coral*/
 		getJsonWebToken()
-			.then(token => {
+			.then(({ token, userIsSignedIn }) => {
 				const scriptElement = document.createElement('script');
 				scriptElement.src = 'https://ft-next-talk-spike.herokuapp.com/static/embed.js';
 				scriptElement.onload = () => Coral.Talk.render(document.querySelector('[data-o-component="o-comments"]'),
 					{
 						talk: 'https://ft-next-talk-spike.herokuapp.com',
 						auth_token: token,
+						userSignedInToFT: userIsSignedIn,
 						events: (events) => {
 							events.onAny((name, data) => {
 								const message = new CustomEvent('talkEvent', {

--- a/src/js/utils/auth/index.js
+++ b/src/js/utils/auth/index.js
@@ -1,8 +1,12 @@
 const getJsonWebToken = () => fetch('https://comments-auth.ft.com/v1/jwt/', {
 	credentials: 'include'
 }).then(response => {
-	if (response.status === 404 || response.status === 205) {
-		return { token: undefined };
+	if (response.status === 404) {
+		return { token: undefined, userIsSignedIn: false };
+	}
+
+	if (response.status === 205) {
+		return { token: undefined, userIsSignedIn: true };
 	}
 
 	if (response.ok) {
@@ -10,8 +14,6 @@ const getJsonWebToken = () => fetch('https://comments-auth.ft.com/v1/jwt/', {
 	}
 
 	throw new Error('Bad response from the authentication service');
-}).then(json => {
-	return json.token;
 });
 
 export {

--- a/test/auth/auth.test.js
+++ b/test/auth/auth.test.js
@@ -28,7 +28,7 @@ describe("Auth", () => {
 
 			it("returns a promise which contains a JSON Web Token as a string", () => {
 				return getJsonWebToken()
-					.then(token => proclaim.isString(token));
+					.then(result => proclaim.isString(result.token));
 			});
 		});
 
@@ -41,11 +41,14 @@ describe("Auth", () => {
 				fetchMock.reset();
 			});
 
-			it("resolves with undefined", () => {
+			it('resolves with an object', () => {
 				return getJsonWebToken()
-					.then((token) => {
-						proclaim.equal(token, undefined);
-					});
+					.then(proclaim.isObject);
+			});
+
+			it("resolves with undefined token", () => {
+				return getJsonWebToken()
+					.then(result => proclaim.equal(result.token, undefined));
 			});
 		});
 
@@ -58,11 +61,14 @@ describe("Auth", () => {
 				fetchMock.reset();
 			});
 
-			it("resolves with undefined", () => {
+			it('resolves with an object', () => {
 				return getJsonWebToken()
-					.then((token) => {
-						proclaim.equal(token, undefined);
-					});
+					.then(proclaim.isObject);
+			});
+
+			it("resolves with undefined token", () => {
+				return getJsonWebToken()
+					.then(result => proclaim.equal(result.token, undefined));
 			});
 		});
 
@@ -75,11 +81,19 @@ describe("Auth", () => {
 				fetchMock.reset();
 			});
 
-			it("resolves with undefined", () => {
+			it('resolves with an object', () => {
 				return getJsonWebToken()
-					.then((token) => {
-						proclaim.equal(token, undefined);
-					});
+					.then(proclaim.isObject);
+			});
+
+			it("resolves with undefined token", () => {
+				return getJsonWebToken()
+					.then(result => proclaim.equal(result.token, undefined));
+			});
+
+			it("resolves with userIsSignedIn true", () => {
+				return getJsonWebToken()
+					.then((result) => proclaim.isTrue(result.userIsSignedIn));
 			});
 		});
 
@@ -92,11 +106,19 @@ describe("Auth", () => {
 				fetchMock.reset();
 			});
 
-			it("resolves with undefined", () => {
+			it('resolves with an object', () => {
 				return getJsonWebToken()
-					.then((token) => {
-						proclaim.equal(token, undefined);
-					});
+					.then(proclaim.isObject);
+			});
+
+			it("resolves with undefined token", () => {
+				return getJsonWebToken()
+					.then(result => proclaim.equal(result.token, undefined));
+			});
+
+			it("resolves with userIsSignedIn false", () => {
+				return getJsonWebToken()
+					.then(result => proclaim.isFalse(result.userIsSignedIn));
 			});
 		});
 


### PR DESCRIPTION
This is needed to display "Sign in to your FT account to comment" link when user is not signed in to their FT account in the Auth plugin.