### PR TITLE
Add `o-comment-count` as a dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,6 +8,7 @@
     "o-comment-api": "^2.3.0",
     "o-comment-ui": "^4.0.1",
     "o-comment-utilities": "^2.3.0",
+    "o-comment-count": "^0.4.0",
     "o-fonts": "^3.0.0",
     "o-colors": "^4.0.0",
     "o-assets": ">=2.0.0 <4",

--- a/main.js
+++ b/main.js
@@ -3,6 +3,7 @@
 const globalEvents = require('./src/javascripts/globalEvents');
 const config = require('./src/javascripts/config.js');
 const oCommentApi = require('o-comment-api');
+const oCommentCount = require('o-comment-count');
 const defaultConfig = require('./config.js');
 const oCommentUtilities = require('o-comment-utilities');
 const Widget = require('./src/javascripts/Widget.js');
@@ -46,6 +47,7 @@ module.exports.init = function (el) {
 };
 module.exports.utilities = oCommentUtilities;
 module.exports.dataService = oCommentApi;
+module.exports.oCommentCount = oCommentCount;
 module.exports.utils = require('./src/javascripts/utils.js');
 module.exports.i18n = require('./src/javascripts/i18n.js');
 module.exports.userDialogs = require('./src/javascripts/userDialogs.js');


### PR DESCRIPTION
In the near future, we'll be deprecating `o-comment-count` and moving its functionality into `o-comments` v6. This change will make it simpler to migrate `next-article` to `o-comments` v6.