### PR TITLE
Use articleID as storyID

### DIFF
--- a/src/js/comments.js
+++ b/src/js/comments.js
@@ -34,6 +34,7 @@ class Comments {
 					{
 						id: 'comments',
 						rootURL: 'https://ft.staging.coral.coralproject.net',
+						storyID: this.options.articleId,
 						autoRender: true
 					}
 				);


### PR DESCRIPTION
If an `articleId` is provided in the options (`data-article-id` attribute when the component is initialized declaratively), we will pass this information as `storyId` to Coral, so that both the FT article and the corresponding story in Coral have the same id.