### PR TITLE
Get JWT token for Coral V5

### DIFF
--- a/src/js/comments.js
+++ b/src/js/comments.js
@@ -27,14 +27,15 @@ class Comments {
 	_renderComments () {
 		/*global Coral*/
 		getJsonWebToken()
-			.then(() => {
+			.then((jwtResponse) => {
 				const scriptElement = document.createElement('script');
 				scriptElement.src = 'https://ft.staging.coral.coralproject.net/assets/js/embed.js';
 				scriptElement.onload = () => Coral.createStreamEmbed(
 					{
 						id: 'comments',
 						rootURL: 'https://ft.staging.coral.coralproject.net',
-						autoRender: true
+						autoRender: true,
+						accessToken: jwtResponse.token
 					}
 				);
 				this.oCommentsEl.appendChild(scriptElement);

--- a/src/js/utils/auth/index.js
+++ b/src/js/utils/auth/index.js
@@ -1,4 +1,4 @@
-const getJsonWebToken = () => fetch('https://comments-auth.ft.com/v1/jwt/', {
+const getJsonWebToken = () => fetch('https://comments-auth.ft.com/v2/jwt/', {
 	credentials: 'include'
 }).then(response => {
 	if (response.status === 404) {

--- a/test/auth/auth.test.js
+++ b/test/auth/auth.test.js
@@ -12,7 +12,7 @@ describe("Auth", () => {
 
 		describe("when comments auth service returns a valid response", () => {
 			before(() => {
-				fetchMock.mock('https://comments-auth.ft.com/v1/jwt/', {
+				fetchMock.mock('https://comments-auth.ft.com/v2/jwt/', {
 					token: '12345'
 				});
 			});
@@ -34,7 +34,7 @@ describe("Auth", () => {
 
 		describe("when the comments auth service response is missing the token", () => {
 			before(() => {
-				fetchMock.mock('https://comments-auth.ft.com/v1/jwt/', {});
+				fetchMock.mock('https://comments-auth.ft.com/v2/jwt/', {});
 			});
 
 			after(() => {
@@ -54,7 +54,7 @@ describe("Auth", () => {
 
 		describe("when the comments auth service response is missing the token", () => {
 			before(() => {
-				fetchMock.mock('https://comments-auth.ft.com/v1/jwt/', {token: undefined});
+				fetchMock.mock('https://comments-auth.ft.com/v2/jwt/', {token: undefined});
 			});
 
 			after(() => {
@@ -74,7 +74,7 @@ describe("Auth", () => {
 
 		describe("when the comments auth service responds with 205", () => {
 			before(() => {
-				fetchMock.mock('https://comments-auth.ft.com/v1/jwt/', 205);
+				fetchMock.mock('https://comments-auth.ft.com/v2/jwt/', 205);
 			});
 
 			after(() => {
@@ -99,7 +99,7 @@ describe("Auth", () => {
 
 		describe("when the comments auth service responds with 404", () => {
 			before(() => {
-				fetchMock.mock('https://comments-auth.ft.com/v1/jwt/', 404);
+				fetchMock.mock('https://comments-auth.ft.com/v2/jwt/', 404);
 			});
 
 			after(() => {
@@ -124,7 +124,7 @@ describe("Auth", () => {
 
 		describe("when the comments auth service responds with a bad response other than 404", () => {
 			before(() => {
-				fetchMock.mock('https://comments-auth.ft.com/v1/jwt/', 500);
+				fetchMock.mock('https://comments-auth.ft.com/v2/jwt/', 500);
 			});
 
 			after(() => {


### PR DESCRIPTION
comments-auth-service now has an endpoint that produces JWT tokens compatible with Coral V5. This PR makes use of that endpoint and feeds the JWT token when creating the embed script.