### PR TITLE
Reintroduce the dispatching of Talk events

### DIFF
--- a/src/js/comments.js
+++ b/src/js/comments.js
@@ -35,7 +35,18 @@ class Comments {
 						id: 'comments',
 						rootURL: 'https://ft.staging.coral.coralproject.net',
 						autoRender: true,
-						accessToken: jwtResponse.token
+						accessToken: jwtResponse.token,
+						events: (events) => {
+							events.onAny((name, data) => {
+								const message = new CustomEvent('talkEvent', {
+									detail: {
+										name,
+										data
+									}
+								});
+								parent.dispatchEvent(message);
+							});
+						}
 					}
 				);
 				this.oCommentsEl.appendChild(scriptElement);


### PR DESCRIPTION
This was removed when we updates to Talk V5 as we wanted to just do the
minimum amount of work to get something visable.

Bringing this back will allow us to track events that are fired in Talk
from within our components and apps.