### PR TITLE
Rename events to work with event listeners

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -7,11 +7,7 @@ In version 6 the commenting provider has been updated from Livefyre to [Coral Ta
 
 #### Event naming
 
-In v6 the naming of events has changed and all events use a dot notation that has three sections.
-
-1. Category
-2. Action
-3. State
+In v6 the naming of events has changed and all events use a dot notation.
 
 The table below shows the mapping of old events to new.
 
@@ -25,13 +21,13 @@ The table below shows the mapping of old events to new.
 | widget.timeout         | Not mapped yet              |
 | widget.ready           | Deprecation candidate       |
 | widget.load            | Deprecation candidate       |
-| widget.renderComplete  | component.render.successful |
-| tracking.postComment   | comment.posted.successful   |
-| tracking.likeComment   | comment.liked.successful    |
+| widget.renderComplete  | o-comments.ready            |
+| tracking.postComment   | o-comments.comment.posted   |
+| tracking.likeComment   | o-comments.comment.liked    |
 | tracking.shareComment  | Deprecation candidate       |
 | tracking.socialMention | Deprecated                  |
-| auth.login             | auth.login.successful       |
-| auth.loginRequired     | auth.login.required         |
+| auth.login             | Not mapped yet              |
+| auth.loginRequired     | Not mapped yet              |
 
 
 ### Migrating from v4 to v5

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The `.on` interface allows you to listen for [events](#events).
 const oComments = require('o-comments');
 const Comments = new oComments();
 
-Comments.on('component.render.successful', () => {
+Comments.on('o-comments.ready', (event) => {
 	console.log('The comments have rendered')
 });
 
@@ -68,31 +68,28 @@ Comments.on('component.render.successful', () => {
 
 #### Events
 
-Events are emitted during key events and can be listened to using the [`.on` interface](#on).
+Events are emitted during key events and can be listened to using the [`.on` interface](#on) or by listening for events on the document.
 
-The naming of events uses a dot notation and follows a `category.action.state` namespacing. The categories and their events are listed below.
+```js
+document.addEventListener('o-comments.ready', (event) => {
+	console.log('This comments have rendered');
+});
+```
 
-
-##### Component
+##### Global / Component 
 
 These events are anything to do with the component itself.
 
-- **component.render.successful** - Emitted when the component has finished rendering and is ready for the user to interact with comments 
+- **o-comments.ready** - Emitted when the component has finished rendering and is ready for the user to interact with comments 
 
 ##### Comment
 
 These events are anything to do with comment interactions.
 
-- **comment.posted.successful** - Emitted when a users has successfully left a comment
-- **comment.posted.toxic** - Emitted when a comment has been flagged as above our acceptable level of toxicity by the automated toxic moderation.
-- **comment.liked.successful** - Emitted when a users has liked a comment
-
-##### Auth
-
-These events are anything to do with users being authenticated.
-
-- **auth.login.successful** - Emitted when a user has successfully logged in to Coral Talk
-- **auth.login.required** - Emitted when a logged out user has performed an action that requires them to login
+- **o-comments.comment.posted** - Emitted when a users has successfully left a comment
+- **o-comments.comment.replied** - Emitted when a user has successfully left a comment which is a reply to an existing comment.
+- **o-comments.comment.edited** - Emitted when a user has successfully edited their existing comment.
+- **o-comments.comment.liked** - Emitted when a users has liked a comment
 
 ### Sass
 _Remember to start your codeblocks with three backticks and "sass" so your markup is syntax highlighted correctly._

--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -1,15 +1,13 @@
 const coralMap = new Map([
-	['query.CoralEmbedStream_Embed.loading', 'component.render.loading'],
-	['query.CoralEmbedStream_Embed.ready', 'component.render.successful'],
-	['mutation.PostComment.success', 'comment.posted.successful'],
-	['mutation.EditComment.success', 'comment.edited.successful'],
-	['mutation.CreateLikeAction.success', 'comment.liked.successful'],
-	['action.TALK_FRAMEWORK_CHECK_LOGIN_SUCCESS', 'auth.login.successful'],
-	['action.SHOW_SIGNIN_DIALOG', 'auth.login.required']
+	['ready', 'o-comments.ready'],
+	['mutation.createComment', 'o-comments.comment.posted'],
+	['mutation.createCommentReply', 'o-comments.comment.replied'],
+	['mutation.editComment', 'o-comments.comment.edited'],
+	['mutation.createCommentReaction', 'o-comments.comment.liked'],
 ]);
 
 const errorMap = new Map([
-	['COMMENT_IS_TOXIC', 'comment.posted.toxic']
+	['COMMENT_IS_TOXIC', 'o-comments.comment.toxic']
 ]);
 
 const validEvents = []

--- a/test/oComments.test.js
+++ b/test/oComments.test.js
@@ -127,7 +127,7 @@ describe("OComments", () => {
 		});
 
 		it("throws a error if it's missing a parameter", () => {
-			proclaim.throws(() => comments.on('component.render.successful'), '.on requires both the `event` & `callback` parameters');
+			proclaim.throws(() => comments.on('o-comments.ready'), '.on requires both the `event` & `callback` parameters');
 		});
 
 		it("throws a error if the event name isn't valid", () => {
@@ -135,81 +135,81 @@ describe("OComments", () => {
 		});
 
 		it("throws a type error if the callback parameter isn't a function", () => {
-			proclaim.throws(() => comments.on('component.render.successful', 'Not a function'),'The callback must be a function');
+			proclaim.throws(() => comments.on('o-comments.ready', 'Not a function'),'The callback must be a function');
 		});
 
 		it("calls the callback when the event is emitted", () => {
-			comments.on('component.render.successful', () => {
+			comments.on('o-comments.ready', () => {
 				eventWasEmitted = true;
 			});
 
-			document.dispatchEvent(new CustomEvent('component.render.successful'));
+			document.dispatchEvent(new CustomEvent('o-comments.ready'));
 
 			proclaim.isTrue(eventWasEmitted);
 		});
 
 		describe("when Coral Talk events are emitted", () => {
-			it("maps the `query.CoralEmbedStream_Embed.ready` event", () => {
-				comments.on('component.render.successful', () => {
+			it("maps the `ready` event", () => {
+				comments.on('o-comments.ready', () => {
 					eventWasEmitted = true;
 				});
 
 				window.dispatchEvent(new CustomEvent('talkEvent', {
 					detail: {
-						name: 'query.CoralEmbedStream_Embed.ready'
+						name: 'ready'
 					}
 				}));
 
 				proclaim.isTrue(eventWasEmitted);
 			});
 
-			it("maps the `mutation.PostComment.success` event", () => {
-				comments.on('comment.posted.successful', () => {
+			it("maps the `mutation.createComment` event", () => {
+				comments.on('o-comments.comment.posted', () => {
 					eventWasEmitted = true;
 				});
 
 				window.dispatchEvent(new CustomEvent('talkEvent', {
 					detail: {
-						name: 'mutation.PostComment.success'
+						name: 'mutation.createComment'
 					}
 				}));
 				proclaim.isTrue(eventWasEmitted);
 			});
 
-			it("maps the `mutation.CreateLikeAction.success` event", () => {
-				comments.on('comment.liked.successful', () => {
+			it("maps the `mutation.createCommentReaction` event", () => {
+				comments.on('o-comments.comment.liked', () => {
 					eventWasEmitted = true;
 				});
 
 				window.dispatchEvent(new CustomEvent('talkEvent', {
 					detail: {
-						name: 'mutation.CreateLikeAction.success'
+						name: 'mutation.createCommentReaction'
 					}
 				}));
 				proclaim.isTrue(eventWasEmitted);
 			});
 
-			it("maps the `action.TALK_FRAMEWORK_CHECK_LOGIN_SUCCESS` event", () => {
-				comments.on('auth.login.successful', () => {
+			it("maps the `mutation.editComment` event", () => {
+				comments.on('o-comments.comment.edited', () => {
 					eventWasEmitted = true;
 				});
 
 				window.dispatchEvent(new CustomEvent('talkEvent', {
 					detail: {
-						name: 'action.TALK_FRAMEWORK_CHECK_LOGIN_SUCCESS'
+						name: 'mutation.editComment'
 					}
 				}));
 				proclaim.isTrue(eventWasEmitted);
 			});
 
-			it("maps the `action.SHOW_SIGNIN_DIALOG` event", () => {
-				comments.on('auth.login.required', () => {
+			it("maps the `mutation.createCommentReply` event", () => {
+				comments.on('o-comments.comment.replied', () => {
 					eventWasEmitted = true;
 				});
 
 				window.dispatchEvent(new CustomEvent('talkEvent', {
 					detail: {
-						name: 'action.SHOW_SIGNIN_DIALOG'
+						name: 'mutation.createCommentReply'
 					}
 				}));
 				proclaim.isTrue(eventWasEmitted);
@@ -217,7 +217,7 @@ describe("OComments", () => {
 
 			describe("when the payload contains an error", () => {
 				it("maps the `COMMENT_IS_TOXIC` error event", () => {
-					comments.on('comment.posted.toxic', () => {
+					comments.on('o-comments.comment.toxic', () => {
 						eventWasEmitted = true;
 					});
 
@@ -245,17 +245,17 @@ describe("OComments", () => {
 					let errorCalled = false;
 					let eventCalled = false;
 
-					comments.on('comment.posted.toxic', () => {
+					comments.on('o-comments.comment.toxic', () => {
 						errorCalled = true;
 					});
 
-					comments.on('comment.edited.successful', () => {
+					comments.on('o-comments.comment.edited', () => {
 						eventCalled = true;
 					});
 
 					window.dispatchEvent(new CustomEvent('talkEvent', {
 						detail: {
-							name: 'mutation.EditComment.success',
+							name: 'mutation.editComment',
 							data: {
 								error: {
 									errors: [


### PR DESCRIPTION
Previously o-comments wasn't mentioned in the event naming because I had
only considered events being accessed via the `.on` method.

However events need to be accessible via event listeners as well and in
this case it would be nicer to include a namespacing.

This also includes some updates based on what events are accessible in
Talk v5