### PR TITLE
Use new authentication endpoint in comments-api

### DIFF
--- a/src/js/utils/auth/index.js
+++ b/src/js/utils/auth/index.js
@@ -1,4 +1,4 @@
-const getJsonWebToken = () => fetch('https://comments-auth.ft.com/v2/jwt/', {
+const getJsonWebToken = () => fetch('https://comments-api.ft.com/user/auth/', {
 	credentials: 'include'
 }).then(response => {
 	if (response.status === 404) {

--- a/test/auth/auth.test.js
+++ b/test/auth/auth.test.js
@@ -12,7 +12,7 @@ describe("Auth", () => {
 
 		describe("when comments auth service returns a valid response", () => {
 			before(() => {
-				fetchMock.mock('https://comments-auth.ft.com/v2/jwt/', {
+				fetchMock.mock('https://comments-api.ft.com/user/auth/', {
 					token: '12345'
 				});
 			});
@@ -34,7 +34,7 @@ describe("Auth", () => {
 
 		describe("when the comments auth service response is missing the token", () => {
 			before(() => {
-				fetchMock.mock('https://comments-auth.ft.com/v2/jwt/', {});
+				fetchMock.mock('https://comments-api.ft.com/user/auth/', {});
 			});
 
 			after(() => {
@@ -54,7 +54,7 @@ describe("Auth", () => {
 
 		describe("when the comments auth service response is missing the token", () => {
 			before(() => {
-				fetchMock.mock('https://comments-auth.ft.com/v2/jwt/', {token: undefined});
+				fetchMock.mock('https://comments-api.ft.com/user/auth/', {token: undefined});
 			});
 
 			after(() => {
@@ -74,7 +74,7 @@ describe("Auth", () => {
 
 		describe("when the comments auth service responds with 205", () => {
 			before(() => {
-				fetchMock.mock('https://comments-auth.ft.com/v2/jwt/', 205);
+				fetchMock.mock('https://comments-api.ft.com/user/auth/', 205);
 			});
 
 			after(() => {
@@ -99,7 +99,7 @@ describe("Auth", () => {
 
 		describe("when the comments auth service responds with 404", () => {
 			before(() => {
-				fetchMock.mock('https://comments-auth.ft.com/v2/jwt/', 404);
+				fetchMock.mock('https://comments-api.ft.com/user/auth/', 404);
 			});
 
 			after(() => {
@@ -124,7 +124,7 @@ describe("Auth", () => {
 
 		describe("when the comments auth service responds with a bad response other than 404", () => {
 			before(() => {
-				fetchMock.mock('https://comments-auth.ft.com/v2/jwt/', 500);
+				fetchMock.mock('https://comments-api.ft.com/user/auth/', 500);
 			});
 
 			after(() => {


### PR DESCRIPTION
We migrated the authentication features from `next-comments-auth-service` to `next-comments-api`. This PR makes o-comments to use the new API.