### PR TITLE
Auth handle comments api error

### DIFF
--- a/src/js/utils/auth/index.js
+++ b/src/js/utils/auth/index.js
@@ -1,11 +1,6 @@
 const getJsonWebToken = () => fetch('https://comments-api.ft.com/user/auth/', {
 	credentials: 'include'
 }).then(response => {
-	// user is not signed in or session token is invalid
-	if (response.status === 404) {
-		return { token: undefined, userIsSignedIn: false };
-	}
-
 	// user is signed in but has no display name
 	if (response.status === 205) {
 		return { token: undefined, userIsSignedIn: true };
@@ -14,9 +9,11 @@ const getJsonWebToken = () => fetch('https://comments-api.ft.com/user/auth/', {
 	// user is signed in and has a pseudonym
 	if (response.ok) {
 		return response.json();
+	} else {
+		// user is not signed in or session token is invalid
+		// or error in comments api
+		return { token: undefined, userIsSignedIn: false };
 	}
-
-	throw new Error('Bad response from the authentication service');
 });
 
 export {

--- a/src/js/utils/auth/index.js
+++ b/src/js/utils/auth/index.js
@@ -1,14 +1,17 @@
 const getJsonWebToken = () => fetch('https://comments-api.ft.com/user/auth/', {
 	credentials: 'include'
 }).then(response => {
+	// user is not signed in or session token is invalid
 	if (response.status === 404) {
 		return { token: undefined, userIsSignedIn: false };
 	}
 
+	// user is signed in but has no display name
 	if (response.status === 205) {
 		return { token: undefined, userIsSignedIn: true };
 	}
 
+	// user is signed in and has a pseudonym
 	if (response.ok) {
 		return response.json();
 	}

--- a/test/auth/auth.test.js
+++ b/test/auth/auth.test.js
@@ -2,7 +2,7 @@
 import proclaim from 'proclaim';
 import fetchMock from 'fetch-mock';
 
-import {getJsonWebToken} from '../..//src/js/utils/auth';
+import {getJsonWebToken} from '../../src/js/utils/auth';
 
 describe("Auth", () => {
 	describe("getJsonWebToken", () => {
@@ -10,7 +10,7 @@ describe("Auth", () => {
 			proclaim.isFunction(getJsonWebToken);
 		});
 
-		describe("when comments auth service returns a valid response", () => {
+		describe("when comments api returns a valid response", () => {
 			before(() => {
 				fetchMock.mock('https://comments-api.ft.com/user/auth/', {
 					token: '12345'
@@ -32,7 +32,7 @@ describe("Auth", () => {
 			});
 		});
 
-		describe("when the comments auth service response is missing the token", () => {
+		describe("when the comments api response is missing the token", () => {
 			before(() => {
 				fetchMock.mock('https://comments-api.ft.com/user/auth/', {});
 			});
@@ -52,7 +52,7 @@ describe("Auth", () => {
 			});
 		});
 
-		describe("when the comments auth service response is missing the token", () => {
+		describe("when the comments api response is missing the token", () => {
 			before(() => {
 				fetchMock.mock('https://comments-api.ft.com/user/auth/', {token: undefined});
 			});
@@ -72,7 +72,7 @@ describe("Auth", () => {
 			});
 		});
 
-		describe("when the comments auth service responds with 205", () => {
+		describe("when the comments api responds with 205", () => {
 			before(() => {
 				fetchMock.mock('https://comments-api.ft.com/user/auth/', 205);
 			});
@@ -97,7 +97,7 @@ describe("Auth", () => {
 			});
 		});
 
-		describe("when the comments auth service responds with 404", () => {
+		describe("when the comments api responds with 404", () => {
 			before(() => {
 				fetchMock.mock('https://comments-api.ft.com/user/auth/', 404);
 			});
@@ -122,7 +122,7 @@ describe("Auth", () => {
 			});
 		});
 
-		describe("when the comments auth service responds with a bad response other than 404", () => {
+		describe("when the comments api responds with a bad response other than 404", () => {
 			before(() => {
 				fetchMock.mock('https://comments-api.ft.com/user/auth/', 500);
 			});

--- a/test/auth/auth.test.js
+++ b/test/auth/auth.test.js
@@ -131,13 +131,19 @@ describe("Auth", () => {
 				fetchMock.reset();
 			});
 
-			it("throws an error", () => {
+			it('resolves with an object', () => {
 				return getJsonWebToken()
-					.then(() => {
-						throw new Error('This should never happen, its just here to make sure the .then is never entered');
-					}).catch((error) => {
-						proclaim.equal(error.message, "Bad response from the authentication service");
-					});
+					.then(proclaim.isObject);
+			});
+
+			it("resolves with undefined token", () => {
+				return getJsonWebToken()
+					.then(result => proclaim.equal(result.token, undefined));
+			});
+
+			it("resolves with userIsSignedIn false", () => {
+				return getJsonWebToken()
+					.then(result => proclaim.isFalse(result.userIsSignedIn));
 			});
 		});
 	});


### PR DESCRIPTION
## What?
Display non-signed-in user experience when comments api `auth` endpoint responds with an error.

## Why?
Currently, when comments-api auth endpoint responds with an error, comments are not rendered on the page at all. This creates confusion when testing the page.
