### PR TITLE
Use parent element id when initializing Coral embed script

### DIFF
--- a/src/js/stream.js
+++ b/src/js/stream.js
@@ -32,7 +32,7 @@ class Stream {
 				scriptElement.src = 'https://ft.staging.coral.coralproject.net/assets/js/embed.js';
 				scriptElement.onload = () => Coral.createStreamEmbed(
 					{
-						id: 'o-comments-stream',
+						id: this.streamEl.id,
 						rootURL: 'https://ft.staging.coral.coralproject.net',
 						autoRender: true,
 						accessToken: jwtResponse.token,


### PR DESCRIPTION
Coral needs the parent element id as a parameter when initialising the embed script, otherwise, we get IntersectionObserver errors. Although we mostly have a static element id, in the apps we will have a dynamically generated element id because of the single page nature of the app. With this change, o-comments will always pass the correct element id to Coral.