### PR TITLE
Replace articleId

### DIFF
--- a/demos/src/count.mustache
+++ b/demos/src/count.mustache
@@ -2,4 +2,5 @@
 	data-o-component="o-comments"
 	data-o-comments-article-id="{{articleId}}"
 	data-o-comments-count="true">
-</div> Comments
+	Comments
+</div>

--- a/demos/src/data/data.json
+++ b/demos/src/data/data.json
@@ -1,3 +1,3 @@
 {
-	"articleId": "b58491f8-be8c-11e9-b350-db00d509634e"
+	"articleId": "a0a253aa-cd56-11e9-b018-ca4456540ea6"
 }


### PR DESCRIPTION
The previous articleId returns null when calling the graphql api so I've
updated it to an articleId that actually returns a comment count.