### PR TITLE
Update the event names to match Origami spec

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -21,9 +21,9 @@ The table below shows the mapping of old events to new.
 | widget.timeout         | Not mapped yet              |
 | widget.ready           | Deprecation candidate       |
 | widget.load            | Deprecation candidate       |
-| widget.renderComplete  | o-comments.ready            |
-| tracking.postComment   | o-comments.comment.posted   |
-| tracking.likeComment   | o-comments.comment.liked    |
+| widget.renderComplete  | oComments.ready             |
+| tracking.postComment   | oComments.postComment       |
+| tracking.likeComment   | ocomments.likeComment       |
 | tracking.shareComment  | Deprecation candidate       |
 | tracking.socialMention | Deprecated                  |
 | auth.login             | Not mapped yet              |

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The `.on` interface allows you to listen for [events](#events).
 const oComments = require('o-comments');
 const Comments = new oComments();
 
-Comments.on('o-comments.ready', (event) => {
+Comments.on('oComments.ready', (event) => {
 	console.log('The comments have rendered')
 });
 
@@ -107,7 +107,7 @@ Comments.on('o-comments.ready', (event) => {
 Events are emitted during key events and can be listened to using the [`.on` interface](#on) or by listening for events on the document.
 
 ```js
-document.addEventListener('o-comments.ready', (event) => {
+document.addEventListener('oComments.ready', (event) => {
 	console.log('This comments have rendered');
 });
 ```
@@ -116,16 +116,17 @@ document.addEventListener('o-comments.ready', (event) => {
 
 These events are anything to do with the component itself.
 
-- **o-comments.ready** - Emitted when the component has finished rendering and is ready for the user to interact with comments
+- **oComments.ready** - Emitted when the component has finished rendering and is ready for the user to interact with comments
 
 #### Comment
 
 These events are anything to do with comment interactions.
 
-- **o-comments.comment.posted** - Emitted when a users has successfully left a comment
-- **o-comments.comment.replied** - Emitted when a user has successfully left a comment which is a reply to an existing comment.
-- **o-comments.comment.edited** - Emitted when a user has successfully edited their existing comment.
-- **o-comments.comment.liked** - Emitted when a users has liked a comment
+- **oComments.postComment** - Emitted when a users has successfully left a comment
+- **oComments.replyComment** - Emitted when a user has successfully left a comment which is a reply to an existing comment.
+- **oComments.editComment** - Emitted when a user has successfully edited their existing comment.
+- **oComments.likeComment** - Emitted when a users has liked a comment
+- **oComments.toxicComment** - Emitted when a user attempted to leave a comment that was flagged as toxic by the auto moderation
 
 ## Sass
 _Remember to start your codeblocks with three backticks and "sass" so your markup is syntax highlighted correctly._

--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -1,13 +1,13 @@
 const coralMap = new Map([
-	['ready', 'o-comments.ready'],
-	['mutation.createComment', 'o-comments.comment.posted'],
-	['mutation.createCommentReply', 'o-comments.comment.replied'],
-	['mutation.editComment', 'o-comments.comment.edited'],
-	['mutation.createCommentReaction', 'o-comments.comment.liked'],
+	['ready', 'oComments.ready'],
+	['mutation.createComment', 'oComments.postComment'],
+	['mutation.createCommentReply', 'oComments.replyComment'],
+	['mutation.editComment', 'oComments.editComment'],
+	['mutation.createCommentReaction', 'oComments.likeComment'],
 ]);
 
 const errorMap = new Map([
-	['COMMENT_IS_TOXIC', 'o-comments.comment.toxic']
+	['COMMENT_IS_TOXIC', 'oComments.toxicComment']
 ]);
 
 const validEvents = []

--- a/test/methods/stream/on.js
+++ b/test/methods/stream/on.js
@@ -18,7 +18,7 @@ module.exports = () => {
 
 	it("throws a error if it's missing a parameter", () => {
 		const stream = new Stream();
-		proclaim.throws(() => stream.on('o-comments.ready'), '.on requires both the `event` & `callback` parameters');
+		proclaim.throws(() => stream.on('oComments.ready'), '.on requires both the `event` & `callback` parameters');
 	});
 
 	it("throws a error if the event name isn't valid", () => {
@@ -28,18 +28,18 @@ module.exports = () => {
 
 	it("throws a type error if the callback parameter isn't a function", () => {
 		const stream = new Stream();
-		proclaim.throws(() => stream.on('o-comments.ready', 'Not a function'),'The callback must be a function');
+		proclaim.throws(() => stream.on('oComments.ready', 'Not a function'),'The callback must be a function');
 	});
 
 	it("calls the callback when the event is emitted", () => {
 		const stream = new Stream();
 		let eventWasEmitted = false;
 
-		stream.on('o-comments.ready', () => {
+		stream.on('oComments.ready', () => {
 			eventWasEmitted = true;
 		});
 
-		document.dispatchEvent(new CustomEvent('o-comments.ready'));
+		document.dispatchEvent(new CustomEvent('oComments.ready'));
 
 		proclaim.isTrue(eventWasEmitted);
 	});
@@ -48,7 +48,7 @@ module.exports = () => {
 		it("maps the `ready` event", (done) => {
 			const stream = new Stream();
 
-			stream.on('o-comments.ready', () => {
+			stream.on('oComments.ready', () => {
 				proclaim.isTrue(true);
 				done();
 			});
@@ -64,7 +64,7 @@ module.exports = () => {
 		it("maps the `mutation.createComment` event", (done) => {
 			const stream = new Stream();
 
-			stream.on('o-comments.comment.posted', () => {
+			stream.on('oComments.postComment', () => {
 				proclaim.isTrue(true);
 				done();
 			});
@@ -79,7 +79,7 @@ module.exports = () => {
 		it("maps the `mutation.createCommentReaction` event", (done) => {
 			const stream = new Stream();
 
-			stream.on('o-comments.comment.liked', () => {
+			stream.on('oComments.likeComment', () => {
 				proclaim.isTrue(true);
 				done();
 			});
@@ -94,7 +94,7 @@ module.exports = () => {
 		it("maps the `mutation.editComment` event", (done) => {
 			const stream = new Stream();
 
-			stream.on('o-comments.comment.edited', () => {
+			stream.on('oComments.editComment', () => {
 				proclaim.isTrue(true);
 				done();
 			});
@@ -109,7 +109,7 @@ module.exports = () => {
 		it("maps the `mutation.createCommentReply` event", (done) => {
 			const stream = new Stream();
 
-			stream.on('o-comments.comment.replied', () => {
+			stream.on('oComments.replyComment', () => {
 				proclaim.isTrue(true);
 				done();
 			});
@@ -125,7 +125,7 @@ module.exports = () => {
 			it("maps the `COMMENT_IS_TOXIC` error event", (done) => {
 				const stream = new Stream();
 
-				stream.on('o-comments.comment.toxic', () => {
+				stream.on('oComments.toxicComment', () => {
 					proclaim.isTrue(true);
 					done();
 				});
@@ -151,7 +151,7 @@ module.exports = () => {
 			it("maps the `COMMENT_IS_TOXIC` error event", (done) => {
 				const stream = new Stream();
 
-				stream.on('o-comments.comment.toxic', () => {
+				stream.on('oComments.toxicComment', () => {
 					proclaim.isTrue(true);
 					done();
 				});
@@ -175,7 +175,7 @@ module.exports = () => {
 			it("maps the valid  event", (done) => {
 				const stream = new Stream();
 
-				stream.on('o-comments.comment.edited', () => {
+				stream.on('oComments.editComment', () => {
 					proclaim.isTrue(true);
 					done();
 				});


### PR DESCRIPTION
I wasn't aware when chosing these event names that event naming was part
of the Origami spec and I broke a bunch of rules.. bad Glynn.

https://origami.ft.com/spec/v1/javascript/#events