### PR TITLE
Expose the stream and count classes from comments

### DIFF
--- a/src/js/comments.js
+++ b/src/js/comments.js
@@ -9,8 +9,13 @@ class Comments {
 		if (isCount) {
 			const count = new Count(rootEl, this.options);
 			count.renderCount();
+
+			return count;
 		} else {
-			new Stream(rootEl, this.options).init();
+			const stream = new Stream(rootEl, this.options);
+			stream.init();
+
+			return stream;
 		}
 	}
 

--- a/test/comments.test.js
+++ b/test/comments.test.js
@@ -21,7 +21,6 @@ describe("Comments", () => {
 			let mockDataAttributeOptions;
 			let sandbox;
 			let mockRootEl;
-			let comments;
 
 			beforeEach(() => {
 				mockDataAttributeOptions = {
@@ -34,7 +33,7 @@ describe("Comments", () => {
 				fixtures.countMarkup();
 
 				mockRootEl = document.querySelector('[data-o-comments-article-id="id"]');
-				comments = new Comments(mockRootEl);
+				new Comments(mockRootEl);
 			});
 
 			afterEach(() => {
@@ -46,55 +45,52 @@ describe("Comments", () => {
 				assert.calledOnce(Comments.getDataAttributes);
 				assert.calledWithExactly(Comments.getDataAttributes, mockRootEl);
 			});
-
-			it("is a defaulted options object", () => {
-				assert.isObject(comments.options);
-				assert.deepEqual(comments.options, {
-					isMockDataAttributeOptions: true
-				});
-				assert.notStrictEqual(comments.options, mockDataAttributeOptions);
-			});
 		});
 	});
 
 	describe("when 'data-o-comments-count' is set to true", () => {
-		let count;
+		let comments;
 
 		beforeEach(() => {
-			count = sinon.stub(Count.prototype, 'renderCount').callsFake(() => true);
 			fixtures.countMarkup();
 			const mockRootEl = document.querySelector('[data-o-comments-article-id="id"]');
-			new Comments(mockRootEl);
+			comments = new Comments(mockRootEl);
 		});
 
 		afterEach(() => {
 			fixtures.reset();
-			count.restore();
 		});
 
-		it("calls new Count", () => {
-			assert.called(count);
+		it("returns the new count instance", () => {
+			assert.isInstanceOf(comments, Count);
+		});
+
+		it("exposes the renderCount method", () => {
+			assert.isInstanceOf(comments.renderCount, Function);
 		});
 	});
 
 	describe("when 'data-o-comments-count' is set to false", () => {
-		let stream;
+		let comments;
 
 		beforeEach(() => {
-			stream = sinon.stub(Stream.prototype, 'init').callsFake(() => true);
 			fixtures.streamMarkup();
 			const mockRootEl = document.querySelector('[data-o-comments-article-id="id"]');
-			new Comments(mockRootEl);
+			comments = new Comments(mockRootEl);
 		});
 
 		afterEach(() => {
 			fixtures.reset();
-			stream.restore();
 		});
 
-		it("calls new Stream", () => {
-			assert.called(stream);
+		it("returns the new Stream instance", () => {
+			assert.isInstanceOf(comments, Stream);
 		});
+
+		['init', 'login', 'getJsonWebToken', 'renderComments', 'on']
+			.forEach(method => it(`exposes the ${method} method`, () => {
+				assert.isInstanceOf(comments[method], Function);
+			}));
 	});
 });
 


### PR DESCRIPTION
When comments is initialised return the relevant class instance for
stream or count. This will allow consumers of comments to access methods
on of sub classes.