### PR TITLE
Refactor events to be more resilient

### DIFF
--- a/src/js/stream.js
+++ b/src/js/stream.js
@@ -8,7 +8,7 @@ class Stream {
 	 * @param {Object} [opts={}] - An options object for configuring the component
 	 */
 	constructor (streamEl, opts = {}) {
-		this.streamEl = streamEl;
+		this.streamEl = streamEl || document;
 		this.options = opts;
 		this.eventSeenTimes = {};
 	}
@@ -110,7 +110,7 @@ class Stream {
 			throw new Error('The callback must be a function');
 		}
 
-		document.addEventListener(event, callback);
+		this.streamEl.addEventListener(event, callback);
 	}
 
 	/**
@@ -155,7 +155,7 @@ class Stream {
 				if (eventHasntBeenSeenRecently) {
 					this.eventSeenTimes[eventName] = now;
 					const event = new CustomEvent(eventName);
-					document.dispatchEvent(event);
+					this.streamEl.dispatchEvent(event);
 				}
 			});
 	}

--- a/src/js/stream.js
+++ b/src/js/stream.js
@@ -7,7 +7,7 @@ class Stream {
 	 * @param {HTMLElement} [streamEl] - The component element in the DOM
 	 * @param {Object} [opts={}] - An options object for configuring the component
 	 */
-	constructor (streamEl, opts) {
+	constructor (streamEl, opts = {}) {
 		this.streamEl = streamEl;
 		this.options = opts;
 		this.validEvents = validEvents;

--- a/src/js/stream.js
+++ b/src/js/stream.js
@@ -1,4 +1,4 @@
-import {validEvents, coralMap, errorMap} from './utils/events';
+import {validEvents, coralEventMap, coralErrorMap} from './utils/events';
 
 class Stream {
 	/**
@@ -10,9 +10,6 @@ class Stream {
 	constructor (streamEl, opts = {}) {
 		this.streamEl = streamEl;
 		this.options = opts;
-		this.validEvents = validEvents;
-		this.coralEventMapping = coralMap;
-		this.errorMapping = errorMap;
 		this.eventSeenTimes = {};
 	}
 
@@ -105,7 +102,7 @@ class Stream {
 			throw new Error('.on requires both the `event` & `callback` parameters');
 		}
 
-		if (!this.validEvents.includes(event)) {
+		if (!validEvents.includes(event)) {
 			throw new Error(`${event} is not a valid event`);
 		}
 
@@ -129,14 +126,14 @@ class Stream {
 			} = {}
 		} = data;
 
-		const mappedEventName = this.coralEventMapping.get(name);
+		const mappedEventName = coralEventMap.get(name);
 		const eventsToPublish = [];
 
 		if (errors && Array.isArray(errors)) {
 			errors
-				.filter(error => this.errorMapping.get(error.translation_key))
+				.filter(error => coralErrorMap.get(error.translation_key))
 				.forEach(error => {
-					const mapppedErrorName = this.errorMapping.get(error.translation_key);
+					const mapppedErrorName = coralErrorMap.get(error.translation_key);
 
 					if (mapppedErrorName) {
 						eventsToPublish.push(mapppedErrorName);

--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -1,4 +1,4 @@
-const coralMap = new Map([
+const coralEventMap = new Map([
 	['ready', 'oComments.ready'],
 	['mutation.createComment', 'oComments.postComment'],
 	['mutation.createCommentReply', 'oComments.replyComment'],
@@ -6,15 +6,15 @@ const coralMap = new Map([
 	['mutation.createCommentReaction', 'oComments.likeComment'],
 ]);
 
-const errorMap = new Map([
+const coralErrorMap = new Map([
 	['COMMENT_IS_TOXIC', 'oComments.toxicComment']
 ]);
 
 const validEvents = []
-	.concat(Array.from(coralMap.values()), Array.from(errorMap.values()));
+	.concat(Array.from(coralEventMap.values()), Array.from(coralErrorMap.values()));
 
 export {
 	validEvents,
-	coralMap,
-	errorMap
+	coralEventMap,
+	coralErrorMap
 };

--- a/test/methods/stream/on.js
+++ b/test/methods/stream/on.js
@@ -39,7 +39,7 @@ module.exports = () => {
 			eventWasEmitted = true;
 		});
 
-		document.dispatchEvent(new CustomEvent('oComments.ready'));
+		stream.publishEvent({name: 'ready'});
 
 		proclaim.isTrue(eventWasEmitted);
 	});
@@ -53,11 +53,7 @@ module.exports = () => {
 				done();
 			});
 
-			window.dispatchEvent(new CustomEvent('talkEvent', {
-				detail: {
-					name: 'ready'
-				}
-			}));
+			stream.publishEvent({name: 'ready'});
 
 		});
 
@@ -69,11 +65,7 @@ module.exports = () => {
 				done();
 			});
 
-			window.dispatchEvent(new CustomEvent('talkEvent', {
-				detail: {
-					name: 'mutation.createComment'
-				}
-			}));
+			stream.publishEvent({name: 'mutation.createComment'});
 		});
 
 		it("maps the `mutation.createCommentReaction` event", (done) => {
@@ -84,11 +76,7 @@ module.exports = () => {
 				done();
 			});
 
-			window.dispatchEvent(new CustomEvent('talkEvent', {
-				detail: {
-					name: 'mutation.createCommentReaction'
-				}
-			}));
+			stream.publishEvent({name: 'mutation.createCommentReaction'});
 		});
 
 		it("maps the `mutation.editComment` event", (done) => {
@@ -99,11 +87,7 @@ module.exports = () => {
 				done();
 			});
 
-			window.dispatchEvent(new CustomEvent('talkEvent', {
-				detail: {
-					name: 'mutation.editComment'
-				}
-			}));
+			stream.publishEvent({name: 'mutation.editComment'});
 		});
 
 		it("maps the `mutation.createCommentReply` event", (done) => {
@@ -114,11 +98,7 @@ module.exports = () => {
 				done();
 			});
 
-			window.dispatchEvent(new CustomEvent('talkEvent', {
-				detail: {
-					name: 'mutation.createCommentReply'
-				}
-			}));
+			stream.publishEvent({name: 'mutation.createCommentReply'});
 		});
 
 		describe("when the payload contains an error", () => {
@@ -130,19 +110,17 @@ module.exports = () => {
 					done();
 				});
 
-				window.dispatchEvent(new CustomEvent('talkEvent', {
-					detail: {
-						data: {
-							error: {
-								errors: [
-									{
-										translation_key: 'COMMENT_IS_TOXIC'
-									}
-								]
-							}
+				stream.publishEvent({
+					data: {
+						error: {
+							errors: [
+								{
+									translation_key: 'COMMENT_IS_TOXIC'
+								}
+							]
 						}
 					}
-				}));
+				});
 			});
 
 		});
@@ -156,20 +134,18 @@ module.exports = () => {
 					done();
 				});
 
-				window.dispatchEvent(new CustomEvent('talkEvent', {
-					detail: {
-						name: 'mutation.editComment',
-						data: {
-							error: {
-								errors: [
-									{
-										translation_key: 'COMMENT_IS_TOXIC'
-									}
-								]
-							}
+				stream.publishEvent({
+					name: 'mutation.editComment',
+					data: {
+						error: {
+							errors: [
+								{
+									translation_key: 'COMMENT_IS_TOXIC'
+								}
+							]
 						}
 					}
-				}));
+				});
 			});
 
 			it("maps the valid  event", (done) => {
@@ -180,20 +156,18 @@ module.exports = () => {
 					done();
 				});
 
-				window.dispatchEvent(new CustomEvent('talkEvent', {
-					detail: {
-						name: 'mutation.editComment',
-						data: {
-							error: {
-								errors: [
-									{
-										translation_key: 'COMMENT_IS_TOXIC'
-									}
-								]
-							}
+				stream.publishEvent({
+					name: 'mutation.editComment',
+					data: {
+						error: {
+							errors: [
+								{
+									translation_key: 'COMMENT_IS_TOXIC'
+								}
+							]
 						}
 					}
-				}));
+				});
 			});
 		});
 	});

--- a/test/methods/stream/on.js
+++ b/test/methods/stream/on.js
@@ -44,6 +44,31 @@ module.exports = () => {
 		proclaim.isTrue(eventWasEmitted);
 	});
 
+	it("throttles events so callbacks are only called every 250 milliseconds", (done) => {
+		const stream = new Stream();
+		let onCount = 0;
+		let listenerCount = 0;
+
+		stream.on('oComments.ready', () => {
+			onCount++;
+		});
+
+		document.addEventListener('oComments.ready', () => {
+			listenerCount++;
+		});
+
+		const interval = window.setInterval(() => {
+			stream.publishEvent({name: 'ready'});
+		}, 10);
+
+		window.setTimeout(() => {
+			proclaim.equal(onCount, 2);
+			proclaim.equal(listenerCount, 2);
+			window.clearInterval(interval);
+			done();
+		}, 270);
+	});
+
 	describe("when Coral Talk events are emitted", () => {
 		it("maps the `ready` event", (done) => {
 			const stream = new Stream();


### PR DESCRIPTION
Refactor how and when the `.on` and `eventListener` events are emitted to the consuming app.

- Reduce reliance on dispatching custom events
- Emit events on stream element not document
- Throttle events that are emitted

## Why

**Reduce reliance on dispatching custom events**
This was done to make the code easier to understand as it can be difficult to follow the when events are fired into the wild and you need to hunt down the listener each time.

**Emit events on stream element not document**
This would allow consuming apps to have multiple comments instances on the page and listen to only listen for events from the relevant instance.

**Throttle events that are emitted**
This gives us some resilience against multiple events firing within quick succession. This could happen if Coral Talk had a bug and events were fired twice. If these events were used to track usage we may over report in this case. Throttling makes sure that only 1 event of a type is emitted during a small time frame.