### PR TITLE
Fix intermittent issue of not being able to sign in

### DIFF
--- a/src/js/stream.js
+++ b/src/js/stream.js
@@ -88,11 +88,11 @@ class Stream {
 							}
 						}
 					);
+					resolve();
 				};
 				this.streamEl.parentNode.appendChild(scriptElement);
 
 				document.dispatchEvent(new Event('oCommentsReady'));
-				resolve();
 			} catch (error) {
 				resolve();
 			}


### PR DESCRIPTION
renderComments promise should be resolved only when this.embed object is initialized.

In production, roughly 2 out of 10 times, this causes user not being able to sign in because by the time the JWT token promise resolves, renderComments promise is also resolved but this.embed is still undefined.