### PR TITLE
Pass staging parameter to auth endpoint

### DIFF
--- a/src/js/stream.js
+++ b/src/js/stream.js
@@ -32,9 +32,9 @@ class Stream {
 	}
 
 	getJsonWebToken () {
-		return fetch('https://comments-api.ft.com/user/auth/', {
-			credentials: 'include'
-		}).then(response => {
+		const url = 'https://comments-api.ft.com/user/auth/' +
+			(this.useStagingEnvironment ? '?staging=1' : '');
+		return fetch(url, { credentials: 'include' }).then(response => {
 			// user is signed in but has no display name
 			if (response.status === 205) {
 				return { token: undefined, userIsSignedIn: true };


### PR DESCRIPTION
Missed this in the previous PR that changes the environment to production.

The JWT token created for production environment is also valid for staging, but the display names can be different between the two environments. This change will ensure we get the correct display name on staging.