### PR TITLE
Pass source app option to jwt endpoint for tracking

### DIFF
--- a/src/js/stream.js
+++ b/src/js/stream.js
@@ -32,8 +32,16 @@ class Stream {
 	}
 
 	getJsonWebToken () {
-		const url = 'https://comments-api.ft.com/user/auth/' +
-			(this.useStagingEnvironment ? '?staging=1' : '');
+		const url = new URL('https://comments-api.ft.com/user/auth/');
+
+		if (this.useStagingEnvironment) {
+			url.searchParams.append('staging', '1');
+		}
+
+		if (this.options.sourceApp) {
+			url.searchParams.append('sourceApp', this.options.sourceApp);
+		}
+
 		return fetch(url, { credentials: 'include' }).then(response => {
 			// user is signed in but has no display name
 			if (response.status === 205) {


### PR DESCRIPTION
We see a few external users in the Coral database. This means some people who aren't supposed to see the new Comments, which is behind a flag, are actually seeing it.

We want to track which app leaks the new Comments to the external users.