### PR TITLE
Use the new display name validation endpoint

### DIFF
--- a/src/js/utils/display-name.js
+++ b/src/js/utils/display-name.js
@@ -11,7 +11,7 @@ const form = `<form id="o-comments-displayname-form" class="o-forms o-forms o-co
 </form>`;
 
 const isUnique = (displayName) => {
-	const url = `https://comments-api.ft.com/user/displayname/${displayName}`;
+	const url = `https://comments-api.ft.com/displayname/isavailable/${displayName}`;
 
 	return fetch(url, { method: 'GET' })
 		.then(response => response.json())


### PR DESCRIPTION
We are deprecating `https://comments-api.ft.com/user/displayname/:displayName` endpoint in favour of `https://comments-api.ft.com/displayname/isavailable/:displayName`.