### PR TITLE
Add an identifier for new comment tracking events

### DIFF
--- a/src/js/stream.js
+++ b/src/js/stream.js
@@ -164,7 +164,8 @@ class Stream {
 						const oTrackingEvent = new CustomEvent('oTracking.event', {
 							detail: {
 								category: 'comment',
-								action: eventMapping.oTracking
+								action: eventMapping.oTracking,
+								coral: true
 							},
 							bubbles: true
 						});


### PR DESCRIPTION
Allow us to separate old comment events from new comment events in our
dashboards.

This will make it easier to monitor the migration to Coral Talk