### PR TITLE
Fixes a bug causing display name validation to fail silently

### DIFF
--- a/src/js/utils/display-name.js
+++ b/src/js/utils/display-name.js
@@ -24,6 +24,11 @@ const findInvalidCharacters = (displayName) => {
 	const containsCharactersNotInCoralTalkRules = /[^a-z0-9_.]/gi;
 	const matchingCharacters = displayName
 		.match(containsCharactersNotInCoralTalkRules);
+
+	if (!matchingCharacters) {
+		return false;
+	}
+
 	const uniqueMatchingCharacters = matchingCharacters.length ?
 		matchingCharacters
 			.filter((character, position) => matchingCharacters.indexOf(character) === position) :

--- a/src/js/utils/display-name.js
+++ b/src/js/utils/display-name.js
@@ -29,7 +29,7 @@ const findInvalidCharacters = (displayName) => {
 		return false;
 	}
 
-	const uniqueMatchingCharacters = matchingCharacters.length ?
+	const uniqueMatchingCharacters = matchingCharacters && matchingCharacters.length ?
 		matchingCharacters
 			.filter((character, position) => matchingCharacters.indexOf(character) === position) :
 		[];

--- a/src/js/utils/display-name.js
+++ b/src/js/utils/display-name.js
@@ -24,11 +24,6 @@ const findInvalidCharacters = (displayName) => {
 	const containsCharactersNotInCoralTalkRules = /[^a-z0-9_.]/gi;
 	const matchingCharacters = displayName
 		.match(containsCharactersNotInCoralTalkRules);
-
-	if (!matchingCharacters) {
-		return false;
-	}
-
 	const uniqueMatchingCharacters = matchingCharacters && matchingCharacters.length ?
 		matchingCharacters
 			.filter((character, position) => matchingCharacters.indexOf(character) === position) :


### PR DESCRIPTION
When the display name doesn't contain any of the invalid characters, the value of variable `matchingCharacters` is `null`. This causes an error in the next line where we check the `length` of `matchingCharacters`.