### PR TITLE
Expose the fetchCount method as getCount

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ Add the following attribute to the markup to enable a comment count:
 
 The comment count is rendered when the `data-o-comments-count` attribute value is `true`.
 
+#### getCount
+
+Should you require the count as a value there is also a `getCount` method that will return an integer.
+
+```js
+Comments.getCount('article-id')
+	.then(count => console.log(count));
+```
+
 ### Use staging environment
 
 Add the following attribute to the markup to use Coral staging environment:

--- a/src/js/comments.js
+++ b/src/js/comments.js
@@ -19,6 +19,10 @@ class Comments {
 		}
 	}
 
+	static getCount (id) {
+		return Count.fetchCount(id);
+	}
+
 	/**
 	 * Get the data attributes from the element. If the component is being set up
 	 * declaratively, this method is used to extract the data attributes from the DOM.


### PR DESCRIPTION
Exposing the Count.fetchCount method as `getCount` on the Comments
instance will allow consumers to just get the raw number without it
being applied to an element.