### PR TITLE
Fixes a bug that causes non-signed-in user experience

### DIFF
--- a/src/js/stream.js
+++ b/src/js/stream.js
@@ -17,7 +17,12 @@ class Stream {
 	}
 
 	init () {
-		return Promise.all([this.renderComments(), this.authenticateUser()]);
+		return Promise.all([this.renderComments(), this.authenticateUser()])
+			.then(() => {
+				if (this.authenticationToken) {
+					this.embed.login(this.authenticationToken);
+				}
+			});
 	}
 
 	authenticateUser (displayName) {
@@ -33,7 +38,11 @@ class Stream {
 		return auth.fetchJsonWebToken(fetchOptions)
 			.then(response => {
 				if (response.token) {
-					this.embed.login(response.token);
+					if (this.embed) {
+						this.embed.login(response.token);
+					} else {
+						this.authenticationToken = response.token;
+					}
 				} else {
 					this.userHasValidSession = response.userHasValidSession;
 				}


### PR DESCRIPTION
This is a bug that happens intermittently and causes a user to get "Sign in to comment" button even when the user is already signed in.

The cause of this bug is a race condition in the authentication mechanism. We are creating `this.embed` object and fetching the JWT token in parallel. When JWT fetch completes before the embed object is created, we call `this.embed.login` against an undefined object.