### PR TITLE
Reduce the rem baseline in order to increase font size

### DIFF
--- a/src/scss/coral-talk-iframe/main.scss
+++ b/src/scss/coral-talk-iframe/main.scss
@@ -21,7 +21,7 @@
 	--font-family-serif: #{inspect($o-typography-sans)};
 
 	// make font sizes consistent in various places
-	--rem-base: 19;
+	--rem-base: 17;
 	--font-size-3: 14px;
 	--font-size-4: 14px;
 


### PR DESCRIPTION
When we brought this up to 19 it made the fonts a bit too small, this
should bring them back up to a sensible size.