### PR TITLE
Hide the not you sign out button with gross css

### DIFF
--- a/src/scss/coral-talk-iframe/main.scss
+++ b/src/scss/coral-talk-iframe/main.scss
@@ -54,6 +54,14 @@
 
 }
 
+// If you don't like gross code then look away now
+// This is just used as a back up plan for hiding the "not you? sign out" part of coral
+// Coral should be removing this functionality for us but until they do we are using gross css to hide it
+
+.coral-viewerBox > div > div > span:not([class]):first-child,
+.coral-viewerBox-logoutButton {
+	display: none;
+}
 
 // remove divider of the top tab bar
 .coral-tabBar {


### PR DESCRIPTION
I am very sorry that this exists but there was no other way to target that element 😢

Coral should be fixing this soon as its a bug and the button and text shouldn't ever appear but as a back up I am adding some css to hide it that makes me want to 🤮