### PR TITLE
DO NOT MERGE: Disable recommend button in Livefyre

### DIFF
--- a/src/stylesheets/livefyre_widget_overrides.scss
+++ b/src/stylesheets/livefyre_widget_overrides.scss
@@ -408,7 +408,6 @@
 			top: 0;
 			padding: 0 0 0 7px;
 			margin: 0 0 0 7px;
-			border-left: 1px solid oColorsGetPaletteColor('black-10');
 		}
 
 		.fyre-comment-like {
@@ -423,13 +422,11 @@
 		}
 
 		.fyre-comment-like-count {
-			font-size: 15px;
-			padding: 0 5px;
-			color: oColorsGetPaletteColor('black-80');
+			display: none;
 		}
 
 		.fyre-comment-like-btn {
-			font-size: 15px;
+			display: none;
 		}
 
 		.fyre-comment-like-imgs {

--- a/src/stylesheets/livefyre_widget_overrides.scss
+++ b/src/stylesheets/livefyre_widget_overrides.scss
@@ -50,8 +50,7 @@
 		}
 
 		.fyre-auth {
-			width: auto;
-			margin: 0;
+			display: none;
 		}
 
 		.fyre-mention {


### PR DESCRIPTION
During the comments migration period, we will stop commenting on old articles that use Livefyre, but the comments will still be visible in the page as read-only.

Livefyre is not able to disable the recommend feature during this period, that's why we hide the recommend button using CSS.

Before:
![before](https://user-images.githubusercontent.com/5130615/67573098-7336b700-f72f-11e9-9ad2-0e67d4efe540.png)

After:
![after](https://user-images.githubusercontent.com/5130615/67573110-77fb6b00-f72f-11e9-8a02-10ceb74f3471.png)


** **WARNING** **
This should not be merged until we stop commenting on old articles.