### PR TITLE
Fix styling bug in the announcement box

### DIFF
--- a/src/scss/coral-talk-iframe/main.scss
+++ b/src/scss/coral-talk-iframe/main.scss
@@ -347,3 +347,20 @@
 		color: oColorsGetPaletteColor(oColorsGetUseCase(link-hover, text)) !important;
 	}
 }
+
+.coral-createComment-message a,
+.coral-createComment-message h1,
+.coral-createComment-message h2,
+.coral-createComment-message h3,
+.coral-createComment-message h4,
+.coral-createComment-message h5,
+.coral-createComment-message h6,
+.coral-configureMessageBox-messageBox a,
+.coral-configureMessageBox-messageBox h1,
+.coral-configureMessageBox-messageBox h2,
+.coral-configureMessageBox-messageBox h3,
+.coral-configureMessageBox-messageBox h4,
+.coral-configureMessageBox-messageBox h5,
+.coral-configureMessageBox-messageBox h6 {
+	color: inherit;
+}


### PR DESCRIPTION
Fixes the bug that causes markdown formatted headings not to appear in the announcement box.

before:
![Screenshot 2019-10-28 at 10 31 03](https://user-images.githubusercontent.com/5130615/67672141-32c57c00-f96f-11e9-8994-6f860f144c8c.png)

after:
![Screenshot 2019-10-28 at 10 31 49](https://user-images.githubusercontent.com/5130615/67672148-378a3000-f96f-11e9-953f-cba69f6c3b1b.png)

