### PR TITLE
Hide livefyre functionality that we don't want to be visible after closing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - run: $HOME/.local/bin/obt verify
       - run: $HOME/.local/bin/obt test
       - run: git clean -fxd
-      - run: npx occ 0.0.0
+      - run: npx occ@0.14.3 --name="${CIRCLE_PROJECT_REPONAME}" 0.0.0
       - run: $HOME/.local/bin/obt install --ignore-bower
       - run: $HOME/.local/bin/obt test --ignore-bower
   publish_to_npm:
@@ -20,7 +20,7 @@ jobs:
       - image: circleci/node:10
     steps:
       - checkout
-      - run: npx occ ${CIRCLE_TAG##v}
+      - run: npx occ@0.14.3 --name="${CIRCLE_PROJECT_REPONAME}" ${CIRCLE_TAG##v}
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > $HOME/.npmrc
       - run: npm publish --access public 
   publish_prerelease_to_npm:
@@ -28,7 +28,7 @@ jobs:
       - image: circleci/node:10
     steps:
       - checkout
-      - run: npx occ ${CIRCLE_TAG##v}
+      - run: npx occ@0.14.3 --name="${CIRCLE_PROJECT_REPONAME}" ${CIRCLE_TAG##v}
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > $HOME/.npmrc
       - run: npm publish --access public --tag=pre-release
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,34 +2,25 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/node:10-browsers
+      - image: 'circleci/node:10-browsers'
     steps:
       - checkout
-      - run: npm config set prefix "$HOME/.local"
-      - run: npm i -g origami-build-tools@^7
-      - run: $HOME/.local/bin/obt install
-      - run: $HOME/.local/bin/obt demo --demo-filter pa11y --suppress-errors
-      - run: $HOME/.local/bin/obt verify
-      - run: $HOME/.local/bin/obt test
-      - run: git clean -fxd
-      - run: npx occ 0.0.0
-      - run: $HOME/.local/bin/obt install --ignore-bower
-      - run: $HOME/.local/bin/obt test --ignore-bower
+      - run: npm install --only=dev
+      - run: npx origami-ci branch
   publish_to_npm:
     docker:
-      - image: circleci/node:10
+      - image: 'circleci/node:10'
     steps:
       - checkout
-      - run: npx occ ${CIRCLE_TAG##v}
-      - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > $HOME/.npmrc
-      - run: npm publish --access public 
+      - run: npm install --only=dev
+      - run: npx origami-ci release
   publish_prerelease_to_npm:
     docker:
-      - image: circleci/node:10
+      - image: 'circleci/node:10'
     steps:
       - checkout
-      - run: npx occ ${CIRCLE_TAG##v}
-      - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > $HOME/.npmrc
+      - run: 'npx occ ${CIRCLE_TAG##v}'
+      - run: 'echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > $HOME/.npmrc'
       - run: npm publish --access public --tag=pre-release
 workflows:
   version: 2
@@ -39,12 +30,12 @@ workflows:
       - publish_to_npm:
           filters:
             tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+              only: '/^v[0-9]+\.[0-9]+\.[0-9]+$/'
             branches:
               ignore: /.*/
       - publish_prerelease_to_npm:
           filters:
             tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+-/
+              only: '/^v[0-9]+\.[0-9]+\.[0-9]+-/'
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - run: $HOME/.local/bin/obt verify
       - run: $HOME/.local/bin/obt test
       - run: git clean -fxd
-      - run: npx occ@0.14.3 --name="${CIRCLE_PROJECT_REPONAME}" 0.0.0
+      - run: npx occ 0.0.0
       - run: $HOME/.local/bin/obt install --ignore-bower
       - run: $HOME/.local/bin/obt test --ignore-bower
   publish_to_npm:
@@ -20,7 +20,7 @@ jobs:
       - image: circleci/node:10
     steps:
       - checkout
-      - run: npx occ@0.14.3 --name="${CIRCLE_PROJECT_REPONAME}" ${CIRCLE_TAG##v}
+      - run: npx occ ${CIRCLE_TAG##v}
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > $HOME/.npmrc
       - run: npm publish --access public 
   publish_prerelease_to_npm:
@@ -28,7 +28,7 @@ jobs:
       - image: circleci/node:10
     steps:
       - checkout
-      - run: npx occ@0.14.3 --name="${CIRCLE_PROJECT_REPONAME}" ${CIRCLE_TAG##v}
+      - run: npx occ ${CIRCLE_TAG##v}
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > $HOME/.npmrc
       - run: npm publish --access public --tag=pre-release
 workflows:

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
-  "name": "o-comments",
-  "private": true,
-  "devDependencies": {
-    "origami-build-tools": "^7.0.0",
-    "gulp": "^3.8.10",
-    "gulp-watch": "^1.1.0",
-    "run-sequence": "^2.0.0",
-    "del": "^1.1.1",
-    "gulp-run": "^1.6.6"
-  }
+	"name": "o-comments",
+	"private": true,
+	"devDependencies": {
+		"origami-build-tools": "^7.0.0",
+		"gulp": "^3.8.10",
+		"gulp-watch": "^1.1.0",
+		"run-sequence": "^2.0.0",
+		"del": "^1.1.1",
+		"gulp-run": "^1.6.6",
+		"origami-ci-tools": "^1.0.0"
+	}
 }

--- a/src/stylesheets/livefyre_widget_overrides.scss
+++ b/src/stylesheets/livefyre_widget_overrides.scss
@@ -408,7 +408,6 @@
 			top: 0;
 			padding: 0 0 0 7px;
 			margin: 0 0 0 7px;
-			border-left: 1px solid oColorsGetPaletteColor('black-10');
 		}
 
 		.fyre-comment-like {
@@ -423,13 +422,11 @@
 		}
 
 		.fyre-comment-like-count {
-			font-size: 15px;
-			padding: 0 5px;
-			color: oColorsGetPaletteColor('black-80');
+			display: none;
 		}
 
 		.fyre-comment-like-btn {
-			font-size: 15px;
+			display: none;
 		}
 
 		.fyre-comment-like-imgs {

--- a/src/stylesheets/livefyre_widget_overrides.scss
+++ b/src/stylesheets/livefyre_widget_overrides.scss
@@ -50,8 +50,7 @@
 		}
 
 		.fyre-auth {
-			width: auto;
-			margin: 0;
+			display: none;
 		}
 
 		.fyre-mention {


### PR DESCRIPTION
We are going to be closing all the livefyre stories to new comments and interactions. Livefyre are able to do this for us for some functionality but are unable to prevent new likes or authentications. For this reason we are hiding this UI via css.

This will then be released as v5.1.2 and we will rebuild all our apps to use this version when we are ready.

I have checked with @JakeChampion and they are happy for the three commits made by @chee to be included in this release as they were in master previously but never released.