### PR TITLE
Move "Signed in as" text above Coral iFrame

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -3,6 +3,7 @@
 @import 'o-spacing/main';
 @import 'o-colors/main';
 @import 'o-fonts/main';
+@import 'o-typography/main';
 
 @import 'src/scss/variables';
 @import 'src/scss/functions';

--- a/src/js/stream.js
+++ b/src/js/stream.js
@@ -19,7 +19,9 @@ class Stream {
 	init () {
 		return Promise.all([this.renderComments(), this.authenticateUser()])
 			.then(() => {
-				Stream.renderSignedInMessage(this.streamEl, this.displayName);
+				if (this.displayName) {
+					Stream.renderSignedInMessage(this.streamEl, this.displayName);
+				}
 
 				if (this.authenticationToken) {
 					this.embed.login(this.authenticationToken);
@@ -193,7 +195,7 @@ class Stream {
 		signedInMessage.innerHTML = `
 								<div class="o-comments__signed-in-container">
 									<p class="o-comments__signed-in-text">Signed in as
-										<span class="o-comments__signed-in-text--inner">${displayName}</span>.
+										<span class="o-comments__signed-in-inner-text">${displayName}</span>.
 									</p>
 								</div>`;
 		streamEl.parentNode.insertBefore(signedInMessage, streamEl);

--- a/src/js/stream.js
+++ b/src/js/stream.js
@@ -192,7 +192,9 @@ class Stream {
 		const signedInMessage = document.createElement('div');
 		signedInMessage.innerHTML = `
 								<div class="o-comments__signed-in-container">
-									<p class="o-comments__signed-in-text">Signed in as ${displayName}</p>
+									<p class="o-comments__signed-in-text">Signed in as
+										<span class="o-comments__signed-in-text--inner">${displayName}</span>.
+									</p>
 								</div>`;
 		streamEl.parentNode.insertBefore(signedInMessage, streamEl);
 	}

--- a/src/js/stream.js
+++ b/src/js/stream.js
@@ -19,6 +19,8 @@ class Stream {
 	init () {
 		return Promise.all([this.renderComments(), this.authenticateUser()])
 			.then(() => {
+				Stream.renderSignedInMessage(this.streamEl, this.displayName);
+
 				if (this.authenticationToken) {
 					this.embed.login(this.authenticationToken);
 				}
@@ -37,6 +39,8 @@ class Stream {
 
 		return auth.fetchJsonWebToken(fetchOptions)
 			.then(response => {
+				this.displayName = response.displayName;
+
 				if (response.token) {
 					if (this.embed) {
 						this.embed.login(response.token);
@@ -182,6 +186,15 @@ class Stream {
 					}
 				}
 			});
+	}
+
+	static renderSignedInMessage (streamEl, displayName) {
+		const signedInMessage = document.createElement('div');
+		signedInMessage.innerHTML = `
+								<div class="o-comments__signed-in-container">
+									<p class="o-comments__signed-in-text">Signed in as ${displayName}</p>
+								</div>`;
+		streamEl.parentNode.insertBefore(signedInMessage, streamEl);
 	}
 }
 

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -17,6 +17,15 @@
 		padding-left: oSpacingByName('s4');
 	}
 
+	.o-comments__signed-in-text {
+		@include oTypographySans($scale: 0);
+	}
+
+	.o-comments__signed-in-text--inner {
+		@include oTypographySans($scale: 2);
+		font-weight: bold;
+	}
+
 	.o-overlay.o-comments__displayname-prompt {
 		background: oColorsGetPaletteColor('paper');
 		padding: 10px;

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -21,7 +21,7 @@
 		@include oTypographySans($scale: 0);
 	}
 
-	.o-comments__signed-in-text--inner {
+	.o-comments__signed-in-inner-text {
 		@include oTypographySans($scale: 2);
 		font-weight: bold;
 	}

--- a/src/scss/coral-talk-iframe/main.scss
+++ b/src/scss/coral-talk-iframe/main.scss
@@ -54,12 +54,7 @@
 
 }
 
-// If you don't like gross code then look away now
-// This is just used as a back up plan for hiding the "not you? sign out" part of coral
-// Coral should be removing this functionality for us but until they do we are using gross css to hide it
-
-.coral-viewerBox > div > div > span:not([class]):first-child,
-.coral-viewerBox-logoutButton {
+.coral-viewerBox {
 	display: none;
 }
 

--- a/test/methods/stream/init.js
+++ b/test/methods/stream/init.js
@@ -42,11 +42,19 @@ module.exports = () => {
 	});
 
 	describe('.renderSignedInMessage', () => {
-		it("creates a div tag for the 'Signed in as' message", () => {
+		beforeEach(() => {
 			sandbox.stub(Stream.prototype, 'renderComments').resolves();
 			sandbox.stub(Stream.prototype, 'authenticateUser').resolves();
+		});
+
+		afterEach(() => {
+			sandbox.restore();
+		});
+
+		it("creates a div tag for the 'Signed in as' message", () => {
 			const mockStreamEl = document.querySelector('[data-o-comments-article-id="id"]');
 			const stream = new Stream(mockStreamEl);
+			stream.displayName = 'fake-display-name';
 
 			return stream.init()
 				.then(() => {
@@ -56,15 +64,13 @@ module.exports = () => {
 		});
 
 		it("renders the correct display name within the 'Signed in as' message", () => {
-			sandbox.stub(Stream.prototype, 'renderComments').resolves();
-			sandbox.stub(Stream.prototype, 'authenticateUser').resolves();
 			const mockStreamEl = document.querySelector('[data-o-comments-article-id="id"]');
 			const stream = new Stream(mockStreamEl);
 			stream.displayName = 'fake-display-name';
 
 			return stream.init()
 				.then(() => {
-					const divTag = document.querySelector('.o-comments__signed-in-text--inner');
+					const divTag = document.querySelector('.o-comments__signed-in-inner-text');
 					proclaim.equal(divTag.innerHTML, 'fake-display-name');
 				});
 		});

--- a/test/methods/stream/init.js
+++ b/test/methods/stream/init.js
@@ -40,5 +40,34 @@ module.exports = () => {
 
 		proclaim.isTrue(authStub.calledOnce);
 	});
+
+	describe('.renderSignedInMessage', () => {
+		it("creates a div tag for the 'Signed in as' message", () => {
+			sandbox.stub(Stream.prototype, 'renderComments').resolves();
+			sandbox.stub(Stream.prototype, 'authenticateUser').resolves();
+			const mockStreamEl = document.querySelector('[data-o-comments-article-id="id"]');
+			const stream = new Stream(mockStreamEl);
+
+			return stream.init()
+				.then(() => {
+					const divTag = document.querySelector('.o-comments__signed-in-container');
+					proclaim.isTrue(!!divTag);
+				});
+		});
+
+		it("renders the correct display name within the 'Signed in as' message", () => {
+			sandbox.stub(Stream.prototype, 'renderComments').resolves();
+			sandbox.stub(Stream.prototype, 'authenticateUser').resolves();
+			const mockStreamEl = document.querySelector('[data-o-comments-article-id="id"]');
+			const stream = new Stream(mockStreamEl);
+			stream.displayName = 'fake-display-name';
+
+			return stream.init()
+				.then(() => {
+					const divTag = document.querySelector('.o-comments__signed-in-text');
+					proclaim.equal(divTag.innerHTML, 'Signed in as fake-display-name');
+				});
+		});
+	});
 };
 

--- a/test/methods/stream/init.js
+++ b/test/methods/stream/init.js
@@ -64,8 +64,8 @@ module.exports = () => {
 
 			return stream.init()
 				.then(() => {
-					const divTag = document.querySelector('.o-comments__signed-in-text');
-					proclaim.equal(divTag.innerHTML, 'Signed in as fake-display-name');
+					const divTag = document.querySelector('.o-comments__signed-in-text--inner');
+					proclaim.equal(divTag.innerHTML, 'fake-display-name');
 				});
 		});
 	});

--- a/test/methods/stream/render-signed-in-message.js
+++ b/test/methods/stream/render-signed-in-message.js
@@ -1,0 +1,21 @@
+import proclaim from 'proclaim';
+import * as fixtures from '../../helpers/fixtures';
+import Stream from '../../../src/js/stream';
+
+module.exports = () => {
+	beforeEach(() => {
+		fixtures.streamMarkup();
+	});
+
+	afterEach(() => {
+		fixtures.reset();
+	});
+
+	it("creates a div tag for the 'Signed in as' message", () => {
+		const mockStreamEl = document.querySelector('[data-o-comments-article-id="id"]');
+		Stream.renderSignedInMessage(mockStreamEl, 'fake-display-name');
+		const divTag = document.querySelector('.o-comments__signed-in-container');
+
+		proclaim.isTrue(!!divTag);
+	});
+};

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -7,6 +7,7 @@ import renderComments from './methods/stream/render-comments';
 import init from './methods/stream/init';
 import authenticateUser from './methods/stream/authenticate-user';
 import publishEvent from './methods/stream/publish-event';
+import renderSignedInMessage from './methods/stream/render-signed-in-message';
 
 describe("Stream", () => {
 	it("is defined", () => {
@@ -17,4 +18,5 @@ describe("Stream", () => {
 	describe('.renderComments', renderComments);
 	describe('.authenticateUser', authenticateUser);
 	describe('.publishEvent', publishEvent);
+	describe('.renderSignedInMessage', renderSignedInMessage);
 });


### PR DESCRIPTION
The "Signed in as" text was moved from inside the iFrame to above it. This will allow us to add an `edit` link beside the text for users to be able to change their display name. Currently, the functionality to edit a display name does not exist because we don't have control over what goes on inside the iFrame.

Before
![image](https://user-images.githubusercontent.com/30316203/68785781-95d53500-0636-11ea-9128-b57e7071da65.png)

After
![image](https://user-images.githubusercontent.com/30316203/68950483-271de600-07b4-11ea-940c-446f23c9514c.png)




