### PR TITLE
Edit display name v7

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -18,7 +18,8 @@
 		"required": [
 			"Map",
 			"fetch",
-			"Array.from"
+			"Array.from",
+			"Element.prototype.remove"
 		]
 	},
 	"ci": {

--- a/src/js/stream.js
+++ b/src/js/stream.js
@@ -198,9 +198,10 @@ class Stream {
 		signedInMessage.classList.add('o-comments__signed-in-container');
 		signedInMessage.innerHTML = `
 									<p class="o-comments__signed-in-text">Signed in as
-										<span class="o-comments__signed-in-inner-text">${this.displayName}</span>.
+										<span class="o-comments__signed-in-inner-text"></span>.
 										<a class="o-comments__edit-display-name">Edit</a>
 									</p>`;
+		signedInMessage.querySelector('.o-comments__signed-in-inner-text').innerText = this.displayName;
 
 		const oldSignedInMessage = this.streamEl.parentNode.querySelector('.o-comments__signed-in-container');
 		if (oldSignedInMessage) {

--- a/src/js/stream.js
+++ b/src/js/stream.js
@@ -36,8 +36,7 @@ class Stream {
 
 	authenticateUser (displayName) {
 		const fetchOptions = {
-			useStagingEnvironment: this.useStagingEnvironment,
-			sourceApp: this.options.sourceApp
+			useStagingEnvironment: this.useStagingEnvironment
 		};
 
 		if (displayName) {

--- a/src/js/stream.js
+++ b/src/js/stream.js
@@ -195,13 +195,18 @@ class Stream {
 
 	renderSignedInMessage () {
 		const signedInMessage = document.createElement('div');
+		signedInMessage.classList.add('o-comments__signed-in-container');
 		signedInMessage.innerHTML = `
-								<div class="o-comments__signed-in-container">
 									<p class="o-comments__signed-in-text">Signed in as
 										<span class="o-comments__signed-in-inner-text">${this.displayName}</span>.
 										<a class="o-comments__edit-display-name">Edit</a>
-									</p>
-								</div>`;
+									</p>`;
+
+		const oldSignedInMessage = this.streamEl.parentNode.querySelector('.o-comments__signed-in-container');
+		if (oldSignedInMessage) {
+			oldSignedInMessage.remove();
+		}
+
 		this.streamEl.parentNode.insertBefore(signedInMessage, this.streamEl);
 
 		document.querySelector('.o-comments__edit-display-name').onclick = () => {

--- a/src/js/stream.js
+++ b/src/js/stream.js
@@ -1,6 +1,7 @@
 import * as events from './utils/events';
 import * as displayName from './utils/display-name';
 import * as auth from './utils/auth';
+import purgeJwtCache from './utils/purge-jwt-cache';
 
 class Stream {
 	/**
@@ -108,7 +109,7 @@ class Stream {
 		});
 	}
 
-	displayNamePrompt () {
+	displayNamePrompt ({purgeCacheAfterCompletion = false}) {
 		const overlay = displayName.prompt();
 
 		document.addEventListener('oOverlay.ready', (event) => {
@@ -124,6 +125,9 @@ class Stream {
 								.then(() => {
 									this.login();
 								});
+							if (purgeCacheAfterCompletion) {
+								purgeJwtCache();
+							}
 						});
 				});
 			}
@@ -211,7 +215,7 @@ class Stream {
 		this.streamEl.parentNode.insertBefore(signedInMessage, this.streamEl);
 
 		document.querySelector('.o-comments__edit-display-name').onclick = () => {
-			this.displayNamePrompt();
+			this.displayNamePrompt({purgeCacheAfterCompletion: true});
 		};
 	}
 }

--- a/src/js/utils/auth.js
+++ b/src/js/utils/auth.js
@@ -9,10 +9,6 @@ export function fetchJsonWebToken (options = {}) {
 		url.searchParams.append('staging', '1');
 	}
 
-	if (options.sourceApp) {
-		url.searchParams.append('sourceApp', options.sourceApp);
-	}
-
 	return fetch(url, { credentials: 'include' }).then(response => {
 		// user is signed in and has a pseudonym
 		if (response.ok) {

--- a/src/js/utils/purge-jwt-cache.js
+++ b/src/js/utils/purge-jwt-cache.js
@@ -1,0 +1,7 @@
+export default function purgeJwtCache() {
+	const url = `https://comments-api.ft.com/user/auth`;
+	return fetch(url, {
+		method: 'PURGE',
+		credentials: 'include'
+	});
+}

--- a/test/methods/stream/authenticate-user.js
+++ b/test/methods/stream/authenticate-user.js
@@ -78,21 +78,41 @@ module.exports = () => {
 			sandbox.restore();
 		});
 
-		it("calls embed.login with the new token", (done) => {
+		it("sets this.authenticationToken to the token", (done) => {
 			sandbox.stub(auth, 'fetchJsonWebToken').resolves({
 				token: 'fake-jwt'
 			});
 
-			const loginStub = sandbox.stub();
 			const stream = new Stream();
-
-			stream.embed = {
-				login: loginStub
-			};
-
 			stream.authenticateUser()
 				.then(() => {
-					proclaim.isTrue(loginStub.calledWith('fake-jwt'));
+					proclaim.equal(stream.authenticationToken, 'fake-jwt');
+					done();
+				});
+
+		});
+
+	});
+
+	describe.only("fetchJsonWebToken returns a displayName", () => {
+		beforeEach(() => {
+			fixtures.streamMarkup();
+		});
+
+		afterEach(() => {
+			fixtures.reset();
+			sandbox.restore();
+		});
+
+		it("sets this.displayName to the display name", (done) => {
+			sandbox.stub(auth, 'fetchJsonWebToken').resolves({
+				displayName: 'fake-display-name'
+			});
+
+			const stream = new Stream();
+			stream.authenticateUser()
+				.then(() => {
+					proclaim.equal(stream.displayName, 'fake-display-name');
 					done();
 				});
 

--- a/test/methods/stream/authenticate-user.js
+++ b/test/methods/stream/authenticate-user.js
@@ -51,21 +51,6 @@ module.exports = () => {
 
 		});
 
-		it("source app option is passed to fetchJsonWebToken", (done) => {
-			const fetchJWTStub = sandbox.stub(auth, 'fetchJsonWebToken').resolves({});
-
-			const stream = new Stream(null, {
-				sourceApp: 'next'
-			});
-
-			stream.authenticateUser()
-				.then(() => {
-					const options = fetchJWTStub.getCall(0).args[0];
-					proclaim.equal(options.sourceApp, 'next');
-					done();
-				});
-		});
-
 	});
 
 	describe("fetchJsonWebToken returns a token", () => {

--- a/test/methods/stream/authenticate-user.js
+++ b/test/methods/stream/authenticate-user.js
@@ -94,7 +94,7 @@ module.exports = () => {
 
 	});
 
-	describe.only("fetchJsonWebToken returns a displayName", () => {
+	describe("fetchJsonWebToken returns a displayName", () => {
 		beforeEach(() => {
 			fixtures.streamMarkup();
 		});

--- a/test/methods/stream/init.js
+++ b/test/methods/stream/init.js
@@ -41,39 +41,18 @@ module.exports = () => {
 		proclaim.isTrue(authStub.calledOnce);
 	});
 
-	describe('.renderSignedInMessage', () => {
-		beforeEach(() => {
-			sandbox.stub(Stream.prototype, 'renderComments').resolves();
-			sandbox.stub(Stream.prototype, 'authenticateUser').resolves();
-		});
+	it("calls .login", () => {
+		sandbox.stub(Stream.prototype, 'renderComments').resolves();
+		sandbox.stub(Stream.prototype, 'authenticateUser').resolves();
+		const mockStreamEl = document.querySelector('[data-o-comments-article-id="id"]');
+		const stream = new Stream(mockStreamEl);
+		const loginStub = sandbox.stub();
+		stream.login = loginStub;
 
-		afterEach(() => {
-			sandbox.restore();
-		});
-
-		it("creates a div tag for the 'Signed in as' message", () => {
-			const mockStreamEl = document.querySelector('[data-o-comments-article-id="id"]');
-			const stream = new Stream(mockStreamEl);
-			stream.displayName = 'fake-display-name';
-
-			return stream.init()
-				.then(() => {
-					const divTag = document.querySelector('.o-comments__signed-in-container');
-					proclaim.isTrue(!!divTag);
-				});
-		});
-
-		it("renders the correct display name within the 'Signed in as' message", () => {
-			const mockStreamEl = document.querySelector('[data-o-comments-article-id="id"]');
-			const stream = new Stream(mockStreamEl);
-			stream.displayName = 'fake-display-name';
-
-			return stream.init()
-				.then(() => {
-					const divTag = document.querySelector('.o-comments__signed-in-inner-text');
-					proclaim.equal(divTag.innerHTML, 'fake-display-name');
-				});
-		});
+		return stream.init()
+			.then(() => {
+				proclaim.isTrue(loginStub.calledOnce);
+			});
 	});
 };
 

--- a/test/methods/stream/login.js
+++ b/test/methods/stream/login.js
@@ -1,0 +1,51 @@
+import proclaim from 'proclaim';
+import sinon from 'sinon/pkg/sinon';
+import * as fixtures from '../../helpers/fixtures';
+import Stream from '../../../src/js/stream';
+
+const sandbox = sinon.createSandbox();
+
+module.exports = () => {
+	beforeEach(() => {
+		fixtures.streamMarkup();
+	});
+
+	afterEach(() => {
+		fixtures.reset();
+		sandbox.restore();
+	});
+
+	describe("authenticationToken exists", () => {
+		it("calls embed.login with the authentication token", () => {
+			const loginStub = sandbox.stub();
+			const stream = new Stream();
+			stream.authenticationToken = 'fake-jwt';
+
+			stream.embed = {
+				login: loginStub
+			};
+
+			stream.login();
+			proclaim.isTrue(loginStub.calledWith('fake-jwt'));
+		});
+	});
+
+	describe("displayName exists", () => {
+		it("calls .renderSignedInMessage", () => {
+			const loginStub = sandbox.stub();
+			const signedInMessageStub = sandbox.stub();
+
+			const stream = new Stream();
+			stream.renderSignedInMessage = signedInMessageStub;
+			stream.authenticationToken = 'fake-jwt';
+			stream.displayName = 'fake-display-name';
+
+			stream.embed = {
+				login: loginStub
+			};
+
+			stream.login();
+			proclaim.isTrue(signedInMessageStub.calledOnce);
+		});
+	});
+};

--- a/test/methods/stream/render-signed-in-message.js
+++ b/test/methods/stream/render-signed-in-message.js
@@ -11,12 +11,37 @@ module.exports = () => {
 		fixtures.reset();
 	});
 
-	it("creates a div tag for the 'Signed in as' message", () => {
+	it("creates a container element for the 'Signed in as' message", () => {
 		const mockStreamEl = document.querySelector('[data-o-comments-article-id="id"]');
 		const stream = new Stream(mockStreamEl);
 		stream.renderSignedInMessage();
-		const divTag = document.querySelector('.o-comments__signed-in-container');
+		const containerEl = document.querySelector('.o-comments__signed-in-container');
 
-		proclaim.isTrue(!!divTag);
+		proclaim.isTrue(!!containerEl);
+	});
+
+	it("renders the display name in the 'Signed in as' message", () => {
+		const mockStreamEl = document.querySelector('[data-o-comments-article-id="id"]');
+		const stream = new Stream(mockStreamEl);
+		stream.displayName = 'fake-display-name';
+		stream.renderSignedInMessage();
+		const displayNameEl = document.querySelector('.o-comments__signed-in-inner-text');
+
+		proclaim.equal(displayNameEl.innerHTML, 'fake-display-name');
+	});
+
+	describe("signed in message already exists on the page", () => {
+		it("removes the old message before inserting the new", () => {
+			const mockStreamEl = document.querySelector('[data-o-comments-article-id="id"]');
+			const stream = new Stream(mockStreamEl);
+			stream.displayName = 'old-display-name';
+			stream.renderSignedInMessage();
+
+			stream.displayName = 'new-display-name';
+			stream.renderSignedInMessage();
+
+			const containerEls = document.querySelectorAll('.o-comments__signed-in-container');
+			proclaim.equal(containerEls.length, 1);
+		});
 	});
 };

--- a/test/methods/stream/render-signed-in-message.js
+++ b/test/methods/stream/render-signed-in-message.js
@@ -13,7 +13,8 @@ module.exports = () => {
 
 	it("creates a div tag for the 'Signed in as' message", () => {
 		const mockStreamEl = document.querySelector('[data-o-comments-article-id="id"]');
-		Stream.renderSignedInMessage(mockStreamEl, 'fake-display-name');
+		const stream = new Stream(mockStreamEl);
+		stream.renderSignedInMessage();
 		const divTag = document.querySelector('.o-comments__signed-in-container');
 
 		proclaim.isTrue(!!divTag);

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -5,6 +5,7 @@ import Stream from '../src/js/stream';
 
 import renderComments from './methods/stream/render-comments';
 import init from './methods/stream/init';
+import login from './methods/stream/login';
 import authenticateUser from './methods/stream/authenticate-user';
 import publishEvent from './methods/stream/publish-event';
 import renderSignedInMessage from './methods/stream/render-signed-in-message';
@@ -15,6 +16,7 @@ describe("Stream", () => {
 	});
 
 	describe('.init', init);
+	describe('.login', login);
 	describe('.renderComments', renderComments);
 	describe('.authenticateUser', authenticateUser);
 	describe('.publishEvent', publishEvent);

--- a/test/utils/auth.test.js
+++ b/test/utils/auth.test.js
@@ -59,28 +59,6 @@ describe('Fetch JSON web token', () => {
 		});
 	});
 
-	describe("when the source app option is passed in", () => {
-		let commentsApiMock;
-
-		before(() => {
-			commentsApiMock = fetchMock.mock('https://comments-api.ft.com/user/auth/?sourceApp=next', {
-				token: '12345'
-			});
-		});
-
-		after(() => {
-			fetchMock.reset();
-		});
-
-		it("appends the source app query parameter to the comments api url", () => {
-			auth.fetchJsonWebToken({
-				sourceApp: 'next'
-			});
-
-			proclaim.isTrue(commentsApiMock.called());
-		});
-	});
-
 	describe("when comments api returns a valid response", () => {
 		before(() => {
 			fetchMock.mock('https://comments-api.ft.com/user/auth/', {


### PR DESCRIPTION
**NOTE**
We have released these changes under branch v6.2.0. This PR is created to get the same changes into master (i.e. v7.x.x).

A user can now update their display name by clicking the edit link and filling out a form. This is a workaround because Coral doesn't support the ability to update a display name under the My Profile tab.

![image](https://user-images.githubusercontent.com/30316203/69249982-bb1df200-0ba6-11ea-95f5-453fb1ac1b5a.png)
