### PR TITLE
Remove sourceApp debug parameter

### DIFF
--- a/src/js/stream.js
+++ b/src/js/stream.js
@@ -36,8 +36,7 @@ class Stream {
 
 	authenticateUser (displayName) {
 		const fetchOptions = {
-			useStagingEnvironment: this.useStagingEnvironment,
-			sourceApp: this.options.sourceApp
+			useStagingEnvironment: this.useStagingEnvironment
 		};
 
 		if (displayName) {

--- a/src/js/utils/auth.js
+++ b/src/js/utils/auth.js
@@ -9,10 +9,6 @@ export function fetchJsonWebToken (options = {}) {
 		url.searchParams.append('staging', '1');
 	}
 
-	if (options.sourceApp) {
-		url.searchParams.append('sourceApp', options.sourceApp);
-	}
-
 	return fetch(url, { credentials: 'include' }).then(response => {
 		// user is signed in and has a pseudonym
 		if (response.ok) {

--- a/test/methods/stream/authenticate-user.js
+++ b/test/methods/stream/authenticate-user.js
@@ -51,21 +51,6 @@ module.exports = () => {
 
 		});
 
-		it("source app option is passed to fetchJsonWebToken", (done) => {
-			const fetchJWTStub = sandbox.stub(auth, 'fetchJsonWebToken').resolves({});
-
-			const stream = new Stream(null, {
-				sourceApp: 'next'
-			});
-
-			stream.authenticateUser()
-				.then(() => {
-					const options = fetchJWTStub.getCall(0).args[0];
-					proclaim.equal(options.sourceApp, 'next');
-					done();
-				});
-		});
-
 	});
 
 	describe("fetchJsonWebToken returns a token", () => {

--- a/test/utils/auth.test.js
+++ b/test/utils/auth.test.js
@@ -59,28 +59,6 @@ describe('Fetch JSON web token', () => {
 		});
 	});
 
-	describe("when the source app option is passed in", () => {
-		let commentsApiMock;
-
-		before(() => {
-			commentsApiMock = fetchMock.mock('https://comments-api.ft.com/user/auth/?sourceApp=next', {
-				token: '12345'
-			});
-		});
-
-		after(() => {
-			fetchMock.reset();
-		});
-
-		it("appends the source app query parameter to the comments api url", () => {
-			auth.fetchJsonWebToken({
-				sourceApp: 'next'
-			});
-
-			proclaim.isTrue(commentsApiMock.called());
-		});
-	});
-
 	describe("when comments api returns a valid response", () => {
 		before(() => {
 			fetchMock.mock('https://comments-api.ft.com/user/auth/', {


### PR DESCRIPTION
We don't need to track the source app for JWT token creation anymore and it makes purging JWT cache more complicated.