### PR TITLE
Adds default value to function parameter

### DIFF
--- a/src/js/stream.js
+++ b/src/js/stream.js
@@ -108,7 +108,7 @@ class Stream {
 		});
 	}
 
-	displayNamePrompt ({purgeCacheAfterCompletion = false}) {
+	displayNamePrompt ({purgeCacheAfterCompletion = false} = {}) {
 		const overlay = displayName.prompt();
 
 		document.addEventListener('oOverlay.ready', (event) => {


### PR DESCRIPTION
This fixes an uncaught error that may happen after setting a display name for the first time.