### PR TITLE
Update event names to match Coral Talk new events

### DIFF
--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -10,7 +10,7 @@ const coralEventMap = new Map([
 			oComments: 'oComments.loginPrompt'
 		}
 	],
-	['mutation.createComment',
+	['createComment.success',
 		{
 			oComments: 'oComments.postComment',
 			oTracking: 'post'
@@ -22,25 +22,25 @@ const coralEventMap = new Map([
 			oTracking: 'reply'
 		}
 	],
-	['mutation.editComment',
+	['createCommentReply.success',
 		{
 			oComments: 'oComments.editComment',
 			oTracking: 'edit'
 		}
 	],
-	['mutation.createCommentReaction',
+	['createCommentReaction.success',
 		{
 			oComments: 'oComments.likeComment',
 			oTracking: 'like'
 		}
 	],
-	['mutation.createCommentFlag',
+	['reportComment.success',
 		{
 			oComments: 'oComments.reportComment',
 			oTracking: 'report'
 		}
 	],
-	['mutation.removeUserIgnore',
+	['ignoreUser.success',
 		{
 			oComments: 'oComments.ignoreUser',
 			oTracking: 'ignore-user'


### PR DESCRIPTION
The event names now match the event names that Coral consider to be
their public event names.

This is the minimum update to get the basic events changed and matches
the behaviour before they changed the event names.

We can still make further improvements to this to track the
auto-moderated comments and to make sure they are not tracked as
successful comments.


I suggest that we only merge this to master / v7 and don't worry about backwards support to v6 as we will be moving off v6 very soon and this doesn't need to be released straight away