### PR TITLE
Track toxic comment event

### DIFF
--- a/src/js/stream.js
+++ b/src/js/stream.js
@@ -152,7 +152,7 @@ class Stream {
 	publishEvent ({name, data = {}}) {
 		const {
 			error: {
-				errors
+				code
 			} = {}
 		} = data;
 
@@ -161,10 +161,10 @@ class Stream {
 		}
 
 		const mappedEvent = events.coralEventMap.get(name);
-		const validErrors = errors && Array.isArray(errors) ? events.findValidErrors(errors) : [];
+		const validError = code ? events.findValidError(code) : [];
 		const eventsToPublish = mappedEvent ?
-			[mappedEvent].concat(validErrors) :
-			validErrors;
+			[mappedEvent].concat(validError) :
+			validError;
 
 		eventsToPublish
 			.forEach(eventMapping => {

--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -49,7 +49,7 @@ const coralEventMap = new Map([
 ]);
 
 const coralErrorMap = new Map([
-	['COMMENT_IS_TOXIC',
+	['TOXIC_COMMENT',
 		{
 			oComments: 'oComments.toxicComment',
 			oTracking: 'post-rejected-toxic'
@@ -57,13 +57,12 @@ const coralErrorMap = new Map([
 	]
 ]);
 
-const findValidErrors = (errors = []) => {
-	return errors
-		.filter(error => coralErrorMap.get(error.translation_key))
-		.map(error => coralErrorMap.get(error.translation_key));
+const findValidError = (code) => {
+	const validError = coralErrorMap.get(code);
+	return validError ? [validError] : [];
 };
 
 export {
 	coralEventMap,
-	findValidErrors
+	findValidError
 };

--- a/test/methods/stream/publish-event.js
+++ b/test/methods/stream/publish-event.js
@@ -133,11 +133,7 @@ module.exports = () => {
 
 			stream.publishEvent({ name: 'oComments.postComment', data: {
 				error: {
-					errors: [
-						{
-							translation_key: 'COMMENT_IS_TOXIC'
-						}
-					]
+					code: 'TOXIC_COMMENT'
 				}
 			}});
 
@@ -157,11 +153,7 @@ module.exports = () => {
 
 			stream.publishEvent({ name: 'oComments.postComment', data: {
 				error: {
-					errors: [
-						{
-							translation_key: 'COMMENT_IS_TOXIC'
-						}
-					]
+					code: 'TOXIC_COMMENT'
 				}
 			}});
 
@@ -194,11 +186,7 @@ module.exports = () => {
 
 			stream.publishEvent({ name: 'oComments.postComment', data: {
 				error: {
-					errors: [
-						{
-							translation_key: 'COMMENT_IS_TOXIC'
-						}
-					]
+					code: 'TOXIC_COMMENT'
 				}
 			}});
 
@@ -219,11 +207,7 @@ module.exports = () => {
 			const interval = window.setInterval(() => {
 				stream.publishEvent({ name: 'oComments.postComment', data: {
 					error: {
-						errors: [
-							{
-								translation_key: 'COMMENT_IS_TOXIC'
-							}
-						]
+						code: 'TOXIC_COMMENT'
 					}
 				}});
 			}, 10);


### PR DESCRIPTION
Coral recently changed how events are emitted, see https://github.com/coralproject/talk/pull/2681#createComment, which broke the way we track toxic comment events. This PR fixes the event tracking in o-comments v7.