### PR TITLE
Destroy display name prompt overlay when closed

### DIFF
--- a/src/js/stream.js
+++ b/src/js/stream.js
@@ -132,14 +132,8 @@ class Stream {
 			}
 		});
 
-		document.addEventListener('oOverlay.close', (event) => {
-			const sourceOverlay = event.srcElement;
-			const displayNameForm = sourceOverlay.querySelector('#o-comments-displayname-form');
-
-			if (displayNameForm) {
-				overlay.destroy();
-			}
-
+		overlay.context.addEventListener('oLayers.close', () => {
+			overlay.destroy();
 		});
 	}
 


### PR DESCRIPTION
With the Origami major update, we started getting an error (o-overlay with id "displayName" already exists) when trying to reopen the display name prompt after once it has been closed.

Because there is no event named `oOverlay.close`, we are now listening to `oLayers.close` and when it is dispatched, we destroy the overlay.