### PR TITLE
Track comments that are withheld for moderation

### DIFF
--- a/src/js/stream.js
+++ b/src/js/stream.js
@@ -145,6 +145,9 @@ class Stream {
 	 */
 	publishEvent ({name, data = {}}) {
 		const {
+			success: {
+				status
+			} = {},
 			error: {
 				code
 			} = {}
@@ -154,40 +157,39 @@ class Stream {
 			return this.displayNamePrompt();
 		}
 
-		const mappedEvent = events.coralEventMap.get(name);
-		const validError = code ? events.findValidError(code) : [];
-		const eventsToPublish = mappedEvent ?
-			[mappedEvent].concat(validError) :
-			validError;
+		const eventNameExists = !!events.coralEventMap.get(name);
+		const mappedEvent = eventNameExists ?
+			events.coralEventMap.get(name):
+			events.coralErrorMap.get(code);
 
-		eventsToPublish
-			.forEach(eventMapping => {
-				const now = +new Date;
-				const delayInMilliseconds = 100;
-				const eventHasntBeenSeenRecently = !this.eventSeenTimes[eventMapping.oComments] ||
-					now > this.eventSeenTimes[eventMapping.oComments] + delayInMilliseconds;
+		if (mappedEvent) {
+			const now = +new Date;
+			const delayInMilliseconds = 100;
+			const eventHasntBeenSeenRecently = !this.eventSeenTimes[mappedEvent.oComments] ||
+				now > this.eventSeenTimes[mappedEvent.oComments] + delayInMilliseconds;
 
-				if (eventHasntBeenSeenRecently) {
-					this.eventSeenTimes[eventMapping.oComments] = now;
+			if (eventHasntBeenSeenRecently) {
+				this.eventSeenTimes[mappedEvent.oComments] = now;
 
-					const oCommentsEvent = new CustomEvent(eventMapping.oComments, {
+				const oCommentsEvent = new CustomEvent(mappedEvent.oComments, {
+					bubbles: true
+				});
+				this.streamEl.dispatchEvent(oCommentsEvent);
+
+				if (mappedEvent.oTracking && !this.options.disableOTracking) {
+					const oTrackingEvent = new CustomEvent('oTracking.event', {
+						detail: {
+							category: 'comment',
+							action: mappedEvent.oTracking,
+							coral: true,
+							isWithheld: status === 'SYSTEM_WITHHELD'
+						},
 						bubbles: true
 					});
-					this.streamEl.dispatchEvent(oCommentsEvent);
-
-					if (eventMapping.oTracking && !this.options.disableOTracking) {
-						const oTrackingEvent = new CustomEvent('oTracking.event', {
-							detail: {
-								category: 'comment',
-								action: eventMapping.oTracking,
-								coral: true
-							},
-							bubbles: true
-						});
-						document.body.dispatchEvent(oTrackingEvent);
-					}
+					document.body.dispatchEvent(oTrackingEvent);
 				}
-			});
+			}
+		}
 	}
 
 	renderSignedInMessage () {

--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -57,12 +57,7 @@ const coralErrorMap = new Map([
 	]
 ]);
 
-const findValidError = (code) => {
-	const validError = coralErrorMap.get(code);
-	return validError ? [validError] : [];
-};
-
 export {
 	coralEventMap,
-	findValidError
+	coralErrorMap
 };

--- a/test/methods/stream/publish-event.js
+++ b/test/methods/stream/publish-event.js
@@ -45,6 +45,7 @@ module.exports = () => {
 				});
 			});
 		});
+
 		it("maps coral events to oComment events", (done) => {
 			const listenerStub = sandbox.stub();
 			document.addEventListener('oComments.ready', () => {
@@ -72,6 +73,23 @@ module.exports = () => {
 			stream.publishEvent({ name: 'ready' });
 
 			proclaim.isTrue(listenerStub.calledOnce);
+		});
+
+		it("sets isWithheld to true when a comment is withheld for moderation", (done) => {
+			const listener = (event) => {
+				proclaim.isTrue(event.detail.isWithheld);
+				done();
+			};
+			document.addEventListener('oTracking.event', listener);
+
+			const stream = new Stream();
+			stream.publishEvent({ name: 'createComment.success', data: {
+				success: {
+					status: 'SYSTEM_WITHHELD'
+				}
+			}});
+
+			document.removeEventListener('oTracking.event', listener);
 		});
 
 		it("doesn't emit oTracking events if it has been disabled", (done) => {


### PR DESCRIPTION
Comments that are flagged for moderation and later approved are
currently not being tracked. This means we are underreporting the
number of comments posted. The Data Team would rather we overreport by
tracking all comments that are flagged for moderation.