### PR TITLE
Remove event listeners after display name prompt overlay is closed

### DIFF
--- a/src/js/stream.js
+++ b/src/js/stream.js
@@ -111,7 +111,7 @@ class Stream {
 	displayNamePrompt ({purgeCacheAfterCompletion = false} = {}) {
 		const overlay = displayName.prompt();
 
-		document.addEventListener('oOverlay.ready', (event) => {
+		const onOverlayReady = (event) => {
 			const sourceOverlay = event.srcElement;
 			const displayNameForm = sourceOverlay.querySelector('#o-comments-displayname-form');
 
@@ -130,17 +130,15 @@ class Stream {
 						});
 				});
 			}
-		});
+		};
+		document.addEventListener('oOverlay.ready', onOverlayReady);
 
-		document.addEventListener('oOverlay.close', (event) => {
-			const sourceOverlay = event.srcElement;
-			const displayNameForm = sourceOverlay.querySelector('#o-comments-displayname-form');
-
-			if (displayNameForm) {
-				overlay.destroy();
-			}
-
-		});
+		const onLayerClose = () => {
+			overlay.context.removeEventListener('oLayers.close', onLayerClose);
+			document.removeEventListener('oOverlay.ready', onOverlayReady);
+			overlay.destroy();
+		};
+		overlay.context.addEventListener('oLayers.close', onLayerClose);
 	}
 
 	/**


### PR DESCRIPTION
Submit and layer close events were firing multiple times when we reopen the display name prompt after closing it. 

This was mainly happening because we used to add an event listener to document for `oOverlay.ready` every time we prompt for display name.

We are now removing this event listeners when the display name pop-up is closed.

We suspect that this was causing performance issues in the app.