### PR TITLE
v7 - Give edit button a unique id

### DIFF
--- a/src/js/stream.js
+++ b/src/js/stream.js
@@ -197,12 +197,13 @@ class Stream {
 	}
 
 	renderSignedInMessage () {
+		const editButtonId = `o-comments-edit-button--${this.streamEl.id}`;
 		const signedInMessage = document.createElement('div');
 		signedInMessage.classList.add('o-comments__signed-in-container');
 		signedInMessage.innerHTML = `
 									<p class="o-comments__signed-in-text">Signed in as
 										<span class="o-comments__signed-in-inner-text"></span>.
-										<a class="o-comments__edit-display-name">Edit</a>
+										<a id="${editButtonId}" class="o-comments__edit-display-name">Edit</a>
 									</p>`;
 		signedInMessage.querySelector('.o-comments__signed-in-inner-text').innerText = this.displayName;
 
@@ -213,7 +214,7 @@ class Stream {
 
 		this.streamEl.parentNode.insertBefore(signedInMessage, this.streamEl);
 
-		document.querySelector('.o-comments__edit-display-name').onclick = () => {
+		document.querySelector(`#${editButtonId}`).onclick = () => {
 			this.displayNamePrompt({purgeCacheAfterCompletion: true});
 		};
 	}

--- a/src/js/stream.js
+++ b/src/js/stream.js
@@ -214,7 +214,7 @@ class Stream {
 
 		this.streamEl.parentNode.insertBefore(signedInMessage, this.streamEl);
 
-		document.querySelector(`#${editButtonId}`).onclick = () => {
+		document.getElementById(editButtonId).onclick = () => {
 			this.displayNamePrompt({purgeCacheAfterCompletion: true});
 		};
 	}


### PR DESCRIPTION
In the FT App, multiple instances of o-comments can be added to the document. Selecting the edit button via a class may not work in that case.

The app always sets a unique id to the o-comments and we make use of that id when giving an id to the edit button. Therefore we will have an edit button with a unique id in each instance of o-comments in the document.