### PR TITLE
Add a display name option

### DIFF
--- a/src/js/stream.js
+++ b/src/js/stream.js
@@ -18,10 +18,16 @@ class Stream {
 	}
 
 	init () {
-		return Promise.all([this.renderComments(), this.authenticateUser()])
-			.then(() => {
-				this.login();
-			});
+		const renderAndAuthenticate = (displayName) => {
+			return Promise.all([this.renderComments(), this.authenticateUser(displayName)])
+				.then(() => {
+					this.login();
+				});
+		};
+
+		return displayName.validation(this.options.displayName)
+			.then(displayName => renderAndAuthenticate(displayName))
+			.catch(() => renderAndAuthenticate());
 	}
 
 	login () {
@@ -117,7 +123,7 @@ class Stream {
 
 			if (displayNameForm) {
 				displayNameForm.addEventListener('submit', (event) => {
-					displayName.validation(event)
+					displayName.promptValidation(event)
 						.then(displayName => {
 							overlay.close();
 							this.authenticateUser(displayName)

--- a/src/js/utils/display-name.js
+++ b/src/js/utils/display-name.js
@@ -21,7 +21,7 @@ const isUnique = (displayName) => {
 		.then(response => response.json())
 		.then(({available}) => {
 			return available;
-		});
+		})
 };
 
 const findInvalidCharacters = (displayName) => {
@@ -63,30 +63,22 @@ const prompt = () => {
 	return overlay;
 };
 
-const validation = (event) => {
-	event.preventDefault();
+const validation = (displayName) => {
+	return new Promise((resolve, reject) => {
 
-	return new Promise(resolve => {
-		const displayNameForm = event.srcElement;
-		const input = displayNameForm.querySelector('input');
-		const displayName = input.value.trim();
-		const errorMessage = displayNameForm.querySelector('#o-comments-displayname-error');
+		if (!displayName) {
+			return reject(new Error('Empty display name'));
+		}
+
 		const invalidCharacters = findInvalidCharacters(displayName);
 
-		errorMessage.innerText = '';
-		displayNameForm.classList.remove('o-forms-input--invalid');
-
-
-
 		if (invalidCharacters) {
-			errorMessage.innerText = `The display name contains the following invalid characters: ${invalidCharacters}`;
-			displayNameForm.classList.add('o-forms-input--invalid');
+			return reject(new Error(`The display name contains the following invalid characters: ${invalidCharacters}`));
 		} else {
 			isUnique(displayName)
 				.then(isUnique => {
 					if (!isUnique) {
-						errorMessage.innerText = 'Unfortunately that display name is already taken';
-						displayNameForm.classList.add('o-forms-input--invalid');
+						return reject(new Error('Unfortunately that display name is already taken'));
 					} else {
 						return resolve(displayName);
 					}
@@ -95,7 +87,30 @@ const validation = (event) => {
 	});
 };
 
+const promptValidation = (event) => {
+	event.preventDefault();
+
+	return new Promise(resolve => {
+		const displayNameForm = event.srcElement;
+		const input = displayNameForm.querySelector('input');
+		const displayName = input.value.trim();
+		const errorMessage = displayNameForm.querySelector('#o-comments-displayname-error');
+
+		errorMessage.innerText = '';
+		displayNameForm.classList.remove('o-forms-input--invalid');
+
+
+		return validation(displayName)
+			.then(displayName => resolve(displayName))
+			.catch(error => {
+				errorMessage.innerText = error.message;
+				displayNameForm.classList.add('o-forms-input--invalid');
+			});
+	});
+};
+
 export {
 	prompt,
-	validation
+	validation,
+	promptValidation
 };

--- a/src/js/utils/display-name.js
+++ b/src/js/utils/display-name.js
@@ -21,7 +21,7 @@ const isUnique = (displayName) => {
 		.then(response => response.json())
 		.then(({available}) => {
 			return available;
-		})
+		});
 };
 
 const findInvalidCharacters = (displayName) => {
@@ -65,7 +65,6 @@ const prompt = () => {
 
 const validation = (displayName) => {
 	return new Promise((resolve, reject) => {
-
 		if (!displayName) {
 			return reject(new Error('Empty display name'));
 		}
@@ -82,6 +81,13 @@ const validation = (displayName) => {
 					} else {
 						return resolve(displayName);
 					}
+				})
+				.catch(() => {
+					const apiError = new Error('Sorry, we are unable to update display names. Please try again later.');
+
+					apiError.name = 'CommentsApiError';
+
+					return reject(apiError);
 				});
 		}
 	});
@@ -105,6 +111,10 @@ const promptValidation = (event) => {
 			.catch(error => {
 				errorMessage.innerText = error.message;
 				displayNameForm.classList.add('o-forms-input--invalid');
+
+				if (error.name === 'CommentsApiError') {
+					throw error;
+				}
 			});
 	});
 };

--- a/test/methods/stream/authenticate-user.js
+++ b/test/methods/stream/authenticate-user.js
@@ -35,6 +35,20 @@ module.exports = () => {
 
 		});
 
+		it("displayName option is not used if undefined", (done) => {
+			const fetchJWTStub = sandbox.stub(auth, 'fetchJsonWebToken').resolves({});
+
+			const stream = new Stream();
+
+			stream.authenticateUser(undefined)
+				.then(() => {
+					const options = fetchJWTStub.getCall(0).args[0];
+					proclaim.isNotString(options.displayName);
+					done();
+				});
+
+		});
+
 		it("staging option is passed to fetchJsonWebToken", (done) => {
 			const fetchJWTStub = sandbox.stub(auth, 'fetchJsonWebToken').resolves({});
 

--- a/test/methods/stream/init.js
+++ b/test/methods/stream/init.js
@@ -2,12 +2,16 @@ import proclaim from 'proclaim';
 import sinon from 'sinon/pkg/sinon';
 import * as fixtures from '../../helpers/fixtures';
 import Stream from '../../../src/js/stream';
+import * as displayName from '../../../src/js/utils/display-name';
 
 const sandbox = sinon.createSandbox();
+let validationStub;
 
 module.exports = () => {
 	beforeEach(() => {
 		fixtures.streamMarkup();
+		validationStub = sandbox.stub(displayName, 'validation');
+		validationStub.rejects();
 	});
 
 	afterEach(() => {
@@ -15,7 +19,7 @@ module.exports = () => {
 		sandbox.restore();
 	});
 
-	it("calls .renderComments", () => {
+	it("calls .renderComments", (done) => {
 		const mockStreamEl = document.querySelector('[data-o-comments-article-id="id"]');
 		const stream = new Stream(mockStreamEl);
 		const renderStub = sandbox.stub();
@@ -23,12 +27,14 @@ module.exports = () => {
 		stream.authenticateUser = authStub;
 		stream.renderComments = renderStub;
 
-		stream.init();
-
-		proclaim.isTrue(renderStub.calledOnce);
+		stream.init()
+			.then(() => {
+				proclaim.isTrue(renderStub.calledOnce);
+				done();
+			});
 	});
 
-	it("calls .authenticateUser", () => {
+	it("calls .authenticateUser", (done) => {
 		const mockStreamEl = document.querySelector('[data-o-comments-article-id="id"]');
 		const stream = new Stream(mockStreamEl);
 		const renderStub = sandbox.stub();
@@ -36,12 +42,55 @@ module.exports = () => {
 		stream.authenticateUser = authStub;
 		stream.renderComments = renderStub;
 
-		stream.init();
+		stream.init()
+			.then(() => {
+				proclaim.isTrue(authStub.calledOnce);
+				done();
+			});
 
-		proclaim.isTrue(authStub.calledOnce);
 	});
 
-	it("calls .login", () => {
+	it("calls .authenticateUser with display name", (done) => {
+		const mockStreamEl = document.querySelector('[data-o-comments-article-id="id"]');
+		const stream = new Stream(mockStreamEl, {
+			displayName: 'test-name'
+		});
+		const renderStub = sandbox.stub();
+		const authStub = sandbox.stub();
+		stream.authenticateUser = authStub;
+		stream.renderComments = renderStub;
+
+		validationStub.resolves('test-name');
+
+		stream.init()
+			.then(() => {
+				proclaim.isTrue(authStub.calledOnce);
+				proclaim.isTrue(authStub.calledWith('test-name'));
+
+				done();
+			});
+
+	});
+
+	it("calls .authenticateUser with display name as undefined", (done) => {
+		const mockStreamEl = document.querySelector('[data-o-comments-article-id="id"]');
+		const stream = new Stream(mockStreamEl);
+		const renderStub = sandbox.stub();
+		const authStub = sandbox.stub();
+		stream.authenticateUser = authStub;
+		stream.renderComments = renderStub;
+
+		stream.init()
+			.then(() => {
+				proclaim.isTrue(authStub.calledOnce);
+				proclaim.isTrue(authStub.calledWith(undefined));
+
+				done();
+			});
+
+	});
+
+	it("calls .login", (done) => {
 		sandbox.stub(Stream.prototype, 'renderComments').resolves();
 		sandbox.stub(Stream.prototype, 'authenticateUser').resolves();
 		const mockStreamEl = document.querySelector('[data-o-comments-article-id="id"]');
@@ -49,9 +98,10 @@ module.exports = () => {
 		const loginStub = sandbox.stub();
 		stream.login = loginStub;
 
-		return stream.init()
+		stream.init()
 			.then(() => {
 				proclaim.isTrue(loginStub.calledOnce);
+				done();
 			});
 	});
 };

--- a/test/utils/display-name.test.js
+++ b/test/utils/display-name.test.js
@@ -1,0 +1,58 @@
+import proclaim from 'proclaim';
+import sinon from 'sinon/pkg/sinon';
+import fetchMock from 'fetch-mock';
+import * as displayName from '../../src/js/utils/display-name';
+
+const sandbox = sinon.createSandbox();
+
+describe('Display name', () => {
+	describe('Validation', () => {
+
+		afterEach(() => {
+			sandbox.restore();
+			fetchMock.reset();
+		});
+
+		it("rejects if the display name doesn't exist", (done) => {
+			displayName.validation()
+				.catch(error => {
+					proclaim.isInstanceOf(error, Error);
+					proclaim.equal(error.message, 'Empty display name');
+					done();
+				});
+		});
+
+		it("rejects if the display name contains invalid characters", (done) => {
+			displayName.validation('test~')
+				.catch(error => {
+					proclaim.isInstanceOf(error, Error);
+					proclaim.equal(error.message, 'The display name contains the following invalid characters: ~');
+					done();
+				});
+		});
+
+		it("rejects if the display name isn't unique", (done) => {
+			fetchMock.mock('begin:https://comments-api.ft.com/displayname/isavailable', {
+				available: false
+			});
+			displayName.validation('test')
+				.catch(error => {
+					proclaim.isInstanceOf(error, Error);
+					proclaim.equal(error.message, 'Unfortunately that display name is already taken');
+					done();
+				});
+		});
+
+		it("resolves if everything passes", (done) => {
+			fetchMock.mock('begin:https://comments-api.ft.com/displayname/isavailable', {
+				available: true
+			});
+
+			displayName.validation('test')
+				.then(displayName => {
+					proclaim.equal(displayName, 'test');
+					done();
+				});
+		});
+	});
+});

--- a/test/utils/display-name.test.js
+++ b/test/utils/display-name.test.js
@@ -43,6 +43,17 @@ describe('Display name', () => {
 				});
 		});
 
+		it("rejects if the comments-api errors", (done) => {
+			fetchMock.mock('begin:https://comments-api.ft.com/displayname/isavailable', 500);
+
+			displayName.validation('test')
+				.catch(error => {
+					proclaim.isInstanceOf(error, Error);
+					proclaim.equal(error.message, 'Sorry, we are unable to update display names. Please try again later.');
+					done();
+				});
+		});
+
 		it("resolves if everything passes", (done) => {
 			fetchMock.mock('begin:https://comments-api.ft.com/displayname/isavailable', {
 				available: true


### PR DESCRIPTION
This will allow the display name to be passed into o-comments as an
option.

This will allow the parent application to set the display name in
advance should it exist. This will be useful for Longroom room where we
want the display name to be set in the user doesn't already have a
commenting account.

The display name that is passed in will need to pass the validation rules.

```
<div class="o-comments"
	id="{element-id}"
	data-o-component="o-comments"
	data-o-comments-display-name="Test display name">
</div>
```