### PR TITLE
Add an aria-label to the comment count element

### DIFF
--- a/src/js/count.js
+++ b/src/js/count.js
@@ -29,7 +29,24 @@ class Count {
 		return Count.fetchCount(this.articleId, this.useStagingEnvironment)
 			.then((count) => {
 				this.countEl.textContent = count;
+
+				const countLabel = Count.getCountLabel(count);
+				this.countEl.setAttribute('aria-label', countLabel);
 			});
+	}
+
+	/**
+	 * Get the aria-label for the count element.
+	 *
+	 * @param {Number} count - The comment count
+	 * @returns {String}
+	 */
+	static getCountLabel (count) {
+		if (count === 1) {
+			return 'There is 1 comment, click to go to the comment section.';
+		} else {
+			return `There are ${count} comments, click to go to the comment section.`;
+		}
 	}
 
 	static fetchCount (id, useStaging) {

--- a/test/count.test.js
+++ b/test/count.test.js
@@ -40,6 +40,56 @@ describe("Count", () => {
 				});
 			});
 
+			describe("when the comment count is 1", () => {
+				beforeEach(() => {
+					sinon.stub(Count, 'fetchCount').withArgs('id').resolves(1);
+					fixtures.countMarkup();
+				});
+
+				afterEach(() => {
+					fixtures.reset();
+					Count.fetchCount.restore();
+				});
+
+				it("doesn't pluralise the text in the aria-label", () => {
+					const mockCountEl = document.querySelector('[data-o-comments-article-id="id"]');
+					const count = new Count(mockCountEl, {
+						articleId: 'id'
+					});
+
+					return count.renderCount()
+						.then(() => {
+							const countLabel = count.countEl.getAttribute('aria-label');
+							assert.equal(countLabel, 'There is 1 comment, click to go to the comment section.');
+						});
+				});
+			});
+
+			describe("when the comment count is greater than 1", () => {
+				beforeEach(() => {
+					sinon.stub(Count, 'fetchCount').withArgs('id').resolves(10);
+					fixtures.countMarkup();
+				});
+
+				afterEach(() => {
+					fixtures.reset();
+					Count.fetchCount.restore();
+				});
+
+				it("pluralises the text in the aria-label", () => {
+					const mockCountEl = document.querySelector('[data-o-comments-article-id="id"]');
+					const count = new Count(mockCountEl, {
+						articleId: 'id'
+					});
+
+					return count.renderCount()
+						.then(() => {
+							const countLabel = count.countEl.getAttribute('aria-label');
+							assert.equal(countLabel, 'There are 10 comments, click to go to the comment section.');
+						});
+				});
+			});
+
 			describe("when initialized with staging option", () => {
 				beforeEach(() => {
 					sinon.stub(Count, 'fetchCount').withArgs('id', true).resolves(20);


### PR DESCRIPTION
The comment count link doesn't clearly indicate its destination or purpose to screen reader users. This PR adds an aria-label to make this more clear.

DAC Ticket: https://trello.com/c/xlaRxOIJ/161-link-purpose-issue-id-daclinkpurpose01