### PR TITLE
Hide the Comments tab bar if user isn't signed in

### DIFF
--- a/src/scss/coral-talk-iframe/main.scss
+++ b/src/scss/coral-talk-iframe/main.scss
@@ -65,6 +65,10 @@ body {
 // remove divider of the top tab bar
 .coral-tabBar {
 	border-bottom-width: 0;
+
+	li:only-child {
+		display: none;
+	}
 }
 
 .coral-tabBarSecondary {


### PR DESCRIPTION
When a user isn't signed in, only the Comments tab appears in the tab
bar. The tab looks like a button and it confuses users. This PR hides
the Comments tab when it's the only one in the bar.

Before:
![image](https://user-images.githubusercontent.com/30316203/73178190-aa3eaf00-4108-11ea-9bbb-e9532513fb4f.png)

After:
![image](https://user-images.githubusercontent.com/30316203/73178235-bf1b4280-4108-11ea-849e-fe0c86da9725.png)