### PR TITLE
Fixes a event naming mapping error

### DIFF
--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -16,13 +16,13 @@ const coralEventMap = new Map([
 			oTracking: 'post'
 		}
 	],
-	['mutation.createCommentReply',
+	['createCommentReply.success',
 		{
 			oComments: 'oComments.replyComment',
 			oTracking: 'reply'
 		}
 	],
-	['createCommentReply.success',
+	['editComment.success',
 		{
 			oComments: 'oComments.editComment',
 			oTracking: 'edit'


### PR DESCRIPTION
I was stupidly mapping the wrong event names to our events. This would
mean that we were not tracking comment edits as we were only tracking
comment replies