### PR TITLE
Track all errors thrown by Coral Talk

### DIFF
--- a/src/js/stream.js
+++ b/src/js/stream.js
@@ -158,19 +158,14 @@ class Stream {
 			success: {
 				status
 			} = {},
-			error: {
-				code
-			} = {}
+			error
 		} = data;
 
 		if (name === 'loginPrompt' && this.userHasValidSession) {
 			return this.displayNamePrompt();
 		}
 
-		const eventNameExists = !!events.coralEventMap.get(name);
-		const mappedEvent = eventNameExists ?
-			events.coralEventMap.get(name):
-			events.coralErrorMap.get(code);
+		const mappedEvent = events.coralEventMap.get(name);
 
 		if (mappedEvent) {
 			const now = +new Date;
@@ -181,21 +176,30 @@ class Stream {
 			if (eventHasntBeenSeenRecently) {
 				this.eventSeenTimes[mappedEvent.oComments] = now;
 
-				const oCommentsEvent = new CustomEvent(mappedEvent.oComments, {
-					bubbles: true
-				});
+				const oCommentsEventOptions = { bubbles: true };
+				if (error) {
+					oCommentsEventOptions.detail = { error };
+				}
+
+				const oCommentsEvent = new CustomEvent(mappedEvent.oComments, oCommentsEventOptions);
 				this.streamEl.dispatchEvent(oCommentsEvent);
 
 				if (mappedEvent.oTracking && !this.options.disableOTracking) {
-					const oTrackingEvent = new CustomEvent('oTracking.event', {
+					const oTrackingEventOptions = {
+						bubbles: true,
 						detail: {
 							category: 'comment',
 							action: mappedEvent.oTracking,
 							coral: true,
 							isWithheld: status === 'SYSTEM_WITHHELD'
-						},
-						bubbles: true
-					});
+						}
+					};
+
+					if (error) {
+						oTrackingEventOptions.detail.error = error;
+					}
+
+					const oTrackingEvent = new CustomEvent('oTracking.event', oTrackingEventOptions);
 					document.body.dispatchEvent(oTrackingEvent);
 				}
 			}

--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -16,6 +16,12 @@ const coralEventMap = new Map([
 			oTracking: 'post'
 		}
 	],
+	['createComment.error',
+		{
+			oComments: 'oComments.errorComment',
+			oTracking: 'post-error'
+		}
+	],
 	['createCommentReply.success',
 		{
 			oComments: 'oComments.replyComment',
@@ -48,16 +54,6 @@ const coralEventMap = new Map([
 	]
 ]);
 
-const coralErrorMap = new Map([
-	['TOXIC_COMMENT',
-		{
-			oComments: 'oComments.toxicComment',
-			oTracking: 'post-rejected-toxic'
-		}
-	]
-]);
-
 export {
-	coralEventMap,
-	coralErrorMap
+	coralEventMap
 };

--- a/test/methods/stream/publish-event.js
+++ b/test/methods/stream/publish-event.js
@@ -133,34 +133,27 @@ module.exports = () => {
 	describe("valid coral error", () => {
 		it("maps coral errors to oComment events", (done) => {
 			const listener = () => {
-				document.removeEventListener('oComments.toxicComment', listener);
+				document.removeEventListener('oComments.errorComment', listener);
 				done();
 			};
-			document.addEventListener('oComments.toxicComment', listener);
+			document.addEventListener('oComments.errorComment', listener);
 
 			const stream = new Stream();
-			stream.publishEvent({
-				name: 'oComments.postComment',
-				data: {
-					error: {
-						code: 'TOXIC_COMMENT'
-					}
-				}
-			});
+			stream.publishEvent({ name: 'createComment.error' });
 		});
 
 		it("maps coral errors to oTracking events", (done) => {
 			const listener = (event) => {
 				document.removeEventListener('oTracking.event', listener);
 				proclaim.equal(event.detail.category, 'comment');
-				proclaim.equal(event.detail.action, 'post-rejected-toxic');
+				proclaim.equal(event.detail.action, 'post-error');
 				done();
 			};
 			document.addEventListener('oTracking.event', listener);
 
 			const stream = new Stream();
 			stream.publishEvent({
-				name: 'oComments.postComment',
+				name: 'createComment.error',
 				data: {
 					error: {
 						code: 'TOXIC_COMMENT'
@@ -171,7 +164,7 @@ module.exports = () => {
 
 		it("doesn't emit oTracking events if it has been disabled", (done) => {
 			const listener = (event) => {
-				if (event.detail.category === 'comment' && event.detail.action === 'post-rejected-toxic') {
+				if (event.detail.category === 'comment' && event.detail.action === 'post-error') {
 					document.removeEventListener('oTracking.event', listener);
 					proclaim.fail('This event should not have been fired');
 				}
@@ -186,7 +179,7 @@ module.exports = () => {
 				disableOTracking: true
 			});
 			stream.publishEvent({
-				name: 'oComments.postComment',
+				name: 'createComment.error',
 				data: {
 					error: {
 						code: 'TOXIC_COMMENT'
@@ -205,7 +198,7 @@ module.exports = () => {
 		it("only maps 1 event every 100 milliseconds", (done) => {
 			const listenerStub = sandbox.stub();
 			const listener = (event) => {
-				if (event.detail.category === 'comment' && event.detail.action === 'post-rejected-toxic') {
+				if (event.detail.category === 'comment' && event.detail.action === 'post-error') {
 					listenerStub();
 				}
 			};
@@ -214,7 +207,7 @@ module.exports = () => {
 			const stream = new Stream();
 			const interval = window.setInterval(() => {
 				stream.publishEvent({
-					name: 'oComments.postComment',
+					name: 'createComment.error',
 					data: {
 						error: {
 							code: 'TOXIC_COMMENT'


### PR DESCRIPTION
Recently, we came across an issue where users were unable comment due to
some internal error on Coral's side. The issue was reported by different
users.

This PR allows us to track any errors and spot issues before it's
reported by users.