### PR TITLE
Increase the contrast of guideline links

### DIFF
--- a/src/scss/coral-talk-iframe/main.scss
+++ b/src/scss/coral-talk-iframe/main.scss
@@ -83,7 +83,7 @@ body {
 }
 
 .coral-guidelines a {
-	@include oTypographyLink;
+	@include oTypographyLink($theme: ('base': 'teal-40', 'hover': 'teal-30'));
 }
 
 


### PR DESCRIPTION
The links in the guidelines box failed the accessibility contrast check when using the standard link colour. This increases the darkness of the link text to pass accessibility checks.