### PR TITLE
Switch edit display name link to be a button

### DIFF
--- a/src/js/stream.js
+++ b/src/js/stream.js
@@ -213,8 +213,8 @@ class Stream {
 		signedInMessage.classList.add('o-comments__signed-in-container');
 		signedInMessage.innerHTML = `
 									<p class="o-comments__signed-in-text">Signed in as
-										<span class="o-comments__signed-in-inner-text"></span>.
-										<a id="${editButtonId}" class="o-comments__edit-display-name">Edit</a>
+										<span class="o-comments__signed-in-inner-text"></span>
+										<button id="${editButtonId}" class="o-comments__edit-display-name">Edit</button>
 									</p>`;
 		signedInMessage.querySelector('.o-comments__signed-in-inner-text').innerText = this.displayName;
 

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -27,11 +27,16 @@
 	}
 
 	.o-comments__signed-in-container {
-		margin-bottom: oSpacingByName('s4');
+		margin-bottom: oSpacingByName('s6');
 	}
 
 	.o-comments__edit-display-name {
-		@include oTypographyLink;
+		@include oButtonsContent($opts: (
+			'type': 'primary',
+			'icon': 'edit'
+		));
+
+		margin-left: oSpacingByName('s2');
 	}
 
 	.o-overlay.o-comments__displayname-prompt {


### PR DESCRIPTION
This improves the semantics of the mark up whilst also improving the
accessibility.

This will allow users to use keyboard navigation to get to the button
and then use the space or enter key to open the modal window.


**Before**
<img width="728" alt="Screenshot before edit display name button change" src="https://user-images.githubusercontent.com/524573/84765273-e3e45980-afc6-11ea-96ca-b22927c41b99.png">


**After**

<img width="729" alt="Screenshot after edit display name button change" src="https://user-images.githubusercontent.com/524573/84765300-f068b200-afc6-11ea-849c-90978542297f.png">
