### PR TITLE
Edit display name dialog a11y

### DIFF
--- a/src/js/utils/display-name.js
+++ b/src/js/utils/display-name.js
@@ -1,16 +1,16 @@
 import Overlay from 'o-overlay';
 
 const form = `<form id="o-comments-displayname-form" class="o-forms o-forms o-comments__displayname-form">
-		<label for="o-comments-displayname-input" class="o-forms-field o-comments__displayname-field">
-			<span class="o-forms-title">Display name</span>
+			<label for="o-comments-displayname-input" class="o-forms-field o-comments__displayname-field">		
+				<span class="o-forms-title">Display name</span>
+			</label>
 			<div class="o-comments__displayname-container">
 				<span class="o-forms-input o-forms-input--text o-comments__displayname-input">
-					<input type="text" name="text" value="" required="">
+					<input id="o-comments-displayname-input" type="text" name="text" value="" required="">
 				</span>
 				<button type="submit" class="o-comments__displayname-submit">Save</button>
 			</div>
 			<span id="o-comments-displayname-error" class="o-forms-input__error o-comments__displayname-error"></span>
-		</label>
 	</form>
 </form>`;
 

--- a/src/js/utils/display-name.js
+++ b/src/js/utils/display-name.js
@@ -10,7 +10,7 @@ const form = `<form id="o-comments-displayname-form" class="o-forms o-forms o-co
 				</span>
 				<button type="submit" class="o-comments__displayname-submit">Save</button>
 			</div>
-			<span id="o-comments-displayname-error" class="o-forms-input__error o-comments__displayname-error"></span>
+			<span id="o-comments-displayname-error" class="o-forms-input__error o-comments__displayname-error" aria-live="assertive"></span>
 	</form>
 </form>`;
 


### PR DESCRIPTION
Addresses DAC_Label_in_Name_Issue2 - Voice activation users were unable to access some elements via their visible label. The label for the ‘Display name’ input wraps around the button and the input field. This is not marked up correctly and could cause issues for assistive technologies.

Solution: Remove wrapping of the label around other elements.

Also announces edit display name dialog error messages.