### PR TITLE
Improve error messages from async tests by passing the error to the `done` callback.

### DIFF
--- a/test/comments.test.js
+++ b/test/comments.test.js
@@ -155,9 +155,13 @@ describe("Comments", () => {
 			it('returns a integer', (done) => {
 				Comments.getCount('article-id')
 					.then(count => {
-						proclaim.isNumber(count);
-						proclaim.equal(count, 4);
-						done();
+						try {
+							proclaim.isNumber(count);
+							proclaim.equal(count, 4);
+							done();
+						} catch (error) {
+							done(error);
+						}
 					});
 			});
 		});
@@ -178,6 +182,9 @@ describe("Comments", () => {
 
 			it('returns a rejected promise', (done) => {
 				Comments.getCount('article-id')
+					.then(() => {
+						done(new Error('should have rejected the promise but instead it was resolved'));
+					})
 					.catch(() => {
 						done();
 					});

--- a/test/methods/stream/publish-event.js
+++ b/test/methods/stream/publish-event.js
@@ -56,9 +56,13 @@ export default function publishEvent () {
 		it("maps coral events to oTracking events", (done) => {
 			const listener = (event) => {
 				document.removeEventListener('oTracking.event', listener);
-				proclaim.equal(event.detail.category, 'comment');
-				proclaim.equal(event.detail.action, 'ready');
-				done();
+				try {
+					proclaim.equal(event.detail.category, 'comment');
+					proclaim.equal(event.detail.action, 'ready');
+					done();
+				} catch (error) {
+					done(error);
+				}
 			};
 			document.addEventListener('oTracking.event', listener);
 
@@ -69,8 +73,12 @@ export default function publishEvent () {
 		it("sets isWithheld to true when a comment is withheld for moderation", (done) => {
 			const listener = (event) => {
 				document.removeEventListener('oTracking.event', listener);
-				proclaim.isTrue(event.detail.isWithheld);
-				done();
+				try {
+					proclaim.isTrue(event.detail.isWithheld);
+					done();
+				} catch (error) {
+					done(error);
+				}
 			};
 			document.addEventListener('oTracking.event', listener);
 
@@ -89,7 +97,7 @@ export default function publishEvent () {
 			const oTrackingEventListener = (event) => {
 				if (event.detail.category === 'comment' && event.detail.action === 'ready') {
 					document.removeEventListener('oTracking.event', oTrackingEventListener);
-					proclaim.fail('This event should not have been fired');
+					done(new Error('This event should not have been fired'));
 				}
 			};
 			document.addEventListener('oTracking.event', oTrackingEventListener);
@@ -122,8 +130,12 @@ export default function publishEvent () {
 			window.setTimeout(() => {
 				window.clearInterval(interval);
 				document.removeEventListener('oComments.ready', listenerStub);
-				proclaim.equal(listenerStub.getCalls().length, 2);
-				done();
+				try {
+					proclaim.equal(listenerStub.getCalls().length, 2);
+					done();
+				} catch (error) {
+					done(error);
+				}
 			}, 120);
 		});
 	});
@@ -143,9 +155,13 @@ export default function publishEvent () {
 		it("maps coral errors to oTracking events", (done) => {
 			const listener = (event) => {
 				document.removeEventListener('oTracking.event', listener);
-				proclaim.equal(event.detail.category, 'comment');
-				proclaim.equal(event.detail.action, 'post-error');
-				done();
+				try {
+					proclaim.equal(event.detail.category, 'comment');
+					proclaim.equal(event.detail.action, 'post-error');
+					done();
+				} catch (error) {
+					done(error);
+				}
 			};
 			document.addEventListener('oTracking.event', listener);
 
@@ -164,7 +180,7 @@ export default function publishEvent () {
 			const listener = (event) => {
 				if (event.detail.category === 'comment' && event.detail.action === 'post-error') {
 					document.removeEventListener('oTracking.event', listener);
-					proclaim.fail('This event should not have been fired');
+					done(new Error('This event should not have been fired'));
 				}
 			};
 			document.addEventListener('oTracking.event', listener);
@@ -217,8 +233,12 @@ export default function publishEvent () {
 			window.setTimeout(() => {
 				window.clearInterval(interval);
 				document.removeEventListener('oTracking.event', listener);
-				proclaim.equal(listenerStub.getCalls().length, 2);
-				done();
+				try {
+					proclaim.equal(listenerStub.getCalls().length, 2);
+					done();
+				} catch (error) {
+					done(error);
+				}
 			}, 120);
 		});
 	});

--- a/test/utils/display-name.test.js
+++ b/test/utils/display-name.test.js
@@ -13,19 +13,33 @@ describe('Display name', () => {
 
 		it("rejects if the display name doesn't exist", (done) => {
 			displayName.validation()
+				.then(() => {
+					done(new Error("Should have rejected but instead resolved"));
+				})
 				.catch(error => {
-					proclaim.isInstanceOf(error, Error);
-					proclaim.equal(error.message, 'Empty display name');
-					done();
+					try {
+						proclaim.isInstanceOf(error, Error);
+						proclaim.equal(error.message, 'Empty display name');
+						done();
+					} catch (error) {
+						done(error);
+					}
 				});
 		});
 
 		it("rejects if the display name contains invalid characters", (done) => {
 			displayName.validation('test~')
+				.then(() => {
+					done(new Error("Should have rejected but instead resolved"));
+				})
 				.catch(error => {
-					proclaim.isInstanceOf(error, Error);
-					proclaim.equal(error.message, 'The display name contains the following invalid characters: ~');
-					done();
+					try {
+						proclaim.isInstanceOf(error, Error);
+						proclaim.equal(error.message, 'The display name contains the following invalid characters: ~');
+						done();
+					} catch (error) {
+						done(error);
+					}
 				});
 		});
 
@@ -34,10 +48,17 @@ describe('Display name', () => {
 				available: false
 			});
 			displayName.validation('test')
+				.then(() => {
+					done(new Error("Should have rejected but instead resolved"));
+				})
 				.catch(error => {
-					proclaim.isInstanceOf(error, Error);
-					proclaim.equal(error.message, 'Unfortunately that display name is already taken');
-					done();
+					try {
+						proclaim.isInstanceOf(error, Error);
+						proclaim.equal(error.message, 'Unfortunately that display name is already taken');
+						done();
+					} catch (error) {
+						done(error);
+					}
 				});
 		});
 
@@ -45,10 +66,17 @@ describe('Display name', () => {
 			fetchMock.mock('begin:https://comments-api.ft.com/displayname/isavailable', 500);
 
 			displayName.validation('test')
+				.then(() => {
+					done(new Error("Should have rejected but instead resolved"));
+				})
 				.catch(error => {
-					proclaim.isInstanceOf(error, Error);
-					proclaim.equal(error.message, 'Sorry, we are unable to update display names. Please try again later.');
-					done();
+					try {
+						proclaim.isInstanceOf(error, Error);
+						proclaim.equal(error.message, 'Sorry, we are unable to update display names. Please try again later.');
+						done();
+					} catch (error) {
+						done(error);
+					}
 				});
 		});
 
@@ -59,8 +87,12 @@ describe('Display name', () => {
 
 			displayName.validation('test')
 				.then(displayName => {
-					proclaim.equal(displayName, 'test');
-					done();
+					try {
+						proclaim.equal(displayName, 'test');
+						done();
+					} catch (error) {
+						done(error);
+					}
 				});
 		});
 	});


### PR DESCRIPTION
If the error is not passed into `done` then mocha does not print out a useful stack trace of where the error originated from.