### PR TITLE
Style updates to improve styling based on Corals latest release (v6.3.2)

### DIFF
--- a/src/scss/coral-talk-iframe/main.scss
+++ b/src/scss/coral-talk-iframe/main.scss
@@ -116,6 +116,10 @@
 	}
 }
 
+.coral-tabBar-comments div i,
+.coral-tabBar-myProfile div i {
+	display: none;
+}
 
 // post comment buttons
 .coral-createComment-submit,

--- a/src/scss/coral-talk-iframe/main.scss
+++ b/src/scss/coral-talk-iframe/main.scss
@@ -214,31 +214,6 @@
 	}
 }
 
-// Because we have increased the margin for .coral-indent-{number} classes
-// We need to hide the icons on comment utility buttons at a wider breakpoint
-// Otherwise the buttons get cut off on smaller screens
-
-// We aren't using o-grid breakpoints because these styles are used within an iframe
-// Which means the width of the document can be controlled by the parent document
-// So the o-grid named sizes (s,m,l) would be confusing in this case
-
-@media (max-width: 400px) {
-	.coral-comment-reactButton,
-	.coral-comment-reactedButton,
-	.coral-comment-replyButton,
-	.coral-comment-shareButton,
-	.coral-comment-reportButton,
-	.coral-featuredComment-reactButton,
-	.coral-featuredComment-replies {
-
-		// This isn't great but its the only way for us to target the icons
-		// If Coral change this markup it could cause a regression
-		i {
-			display: none !important;
-		}
-	}
-}
-
 .coral-featuredComment-replies div {
 	color: oColorsByName('teal-50');
 }

--- a/src/scss/coral-talk-iframe/main.scss
+++ b/src/scss/coral-talk-iframe/main.scss
@@ -105,7 +105,6 @@
 	// normally, these should come for free with oButtons mixin
 	// but we have to declare this explicitly here because
 	// Coral styles override our styles for some reason
-	&[aria-selected=true],
 	&[aria-pressed=true],
 	&[aria-current] {
 		color: oButtonsGetColor($state: 'default', $property: 'color', $type: 'primary') !important;
@@ -113,6 +112,13 @@
 		border-color: oButtonsGetColor($state: 'default', $property: 'border', $type: 'primary') !important;
 		border-top: 1px !important;
 		border-bottom: 1px !important;
+	}
+
+	&[aria-selected=true] {
+		color: oButtonsGetColor($state: 'default', $property: 'color', $type: 'primary') !important;
+		background-color: oButtonsGetColor($state: 'default', $property: 'background', $type: 'primary') !important;
+		border-top: 1px !important;
+		border-bottom: 1px solid oButtonsGetColor($state: 'default', $property: 'background', $type: 'primary') !important;
 	}
 }
 


### PR DESCRIPTION
This fixes 3 issues that were introduced in the latest Coral release.

## Tab icons

**Before**
<img width="378" alt="Screenshot of tab icons that we don't want" src="https://user-images.githubusercontent.com/524573/90761178-f2a6ff80-e2da-11ea-88d3-f47181264f32.png">

**After**
<img width="238" alt="Screenshot of tabs in the correct styling" src="https://user-images.githubusercontent.com/524573/90761348-2e41c980-e2db-11ea-9d2b-a797f3b79940.png">

## Selected tab border styles

Shown in the screenshots above, all the tabs are now the same height.

## Comment action buttons

**Before**
I didn't get a screenshot of this as I tried to fix it quick and forgot - The icons below the comment for recommend, reply, share and flag were missing.

**After**
<img width="181" alt="Screenshot showing comment action icons" src="https://user-images.githubusercontent.com/524573/90761453-55989680-e2db-11ea-86ad-e9a6ba18b54b.png">
