### PR TITLE
remove the ci section from origami.json and circle badge from the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# o-comments [![Circle CI](https://circleci.com/gh/Financial-Times/o-comments/tree/master.svg?style=svg)](https://circleci.com/gh/Financial-Times/o-comments/tree/master) [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](#licence)
+# o-comments [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](#licence)
 
 A component, integrated with FT authentication and [Coral Talk](https://coralproject.net), to add a comment stream or comment count to content.
 

--- a/origami.json
+++ b/origami.json
@@ -22,9 +22,6 @@
 			"Element.prototype.remove"
 		]
 	},
-	"ci": {
-		"circle": "https://circleci.com/api/v1/project/Financial-Times/o-comments"
-	},
 	"demosDefaults": {
 		"js": "demos/src/demo.js",
 		"data": "demos/src/data/data.json",


### PR DESCRIPTION
The ci section was out of date and is not required.
The badge points to the old CI, this uses GitHub CI now.