### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/demos/src/demo.js
+++ b/demos/src/demo.js
@@ -1,3 +1,3 @@
-import Comments from '../../main.js';
+import Comments from '../../main.js.js';
 
 Comments.init();

--- a/demos/src/demo.js
+++ b/demos/src/demo.js
@@ -1,3 +1,3 @@
-import Comments from '../../main.js.js';
+import Comments from '../../main.js';
 
 Comments.init();

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import Comments from './src/js/comments';
+import Comments from './src/js/comments.js';
 
 const constructAll = function () {
 	Comments.init();

--- a/src/js/comments.js
+++ b/src/js/comments.js
@@ -1,5 +1,5 @@
-import Stream from './stream';
-import Count from './count';
+import Stream from './stream.js';
+import Count from './count.js';
 
 class Comments {
 	constructor (rootEl, opts) {

--- a/src/js/stream.js
+++ b/src/js/stream.js
@@ -1,7 +1,7 @@
-import * as events from './utils/events';
-import * as displayName from './utils/display-name';
-import * as auth from './utils/auth';
-import purgeJwtCache from './utils/purge-jwt-cache';
+import * as events from './utils/events.js';
+import * as displayName from './utils/display-name.js';
+import * as auth from './utils/auth.js';
+import purgeJwtCache from './utils/purge-jwt-cache.js';
 
 class Stream {
 	/**

--- a/test/comments.test.js
+++ b/test/comments.test.js
@@ -1,10 +1,10 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 import fetchMock from 'fetch-mock';
-import * as fixtures from './helpers/fixtures';
-import Comments from '../src/js/comments';
-import Count from '../src/js/count';
-import Stream from '../src/js/stream';
+import * as fixtures from './helpers/fixtures.js';
+import Comments from '../src/js/comments.js';
+import Count from '../src/js/count.js';
+import Stream from '../src/js/stream.js';
 
 describe("Comments", () => {
 	it("is defined", () => {

--- a/test/count.test.js
+++ b/test/count.test.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
-import * as fixtures from './helpers/fixtures';
+import * as fixtures from './helpers/fixtures.js';
 import fetchMock from 'fetch-mock';
-import Count from '../src/js/count';
+import Count from '../src/js/count.js';
 
 sinon.assert.expose(proclaim, {
 	includeFail: false,

--- a/test/methods/stream/authenticate-user.js
+++ b/test/methods/stream/authenticate-user.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
-import * as fixtures from '../../helpers/fixtures';
-import Stream from '../../../src/js/stream';
-import * as auth from '../../../src/js/utils/auth';
+import * as fixtures from '../../helpers/fixtures.js';
+import Stream from '../../../src/js/stream.js';
+import * as auth from '../../../src/js/utils/auth.js';
 
 let fetchJWTStub;
 

--- a/test/methods/stream/display-name-prompt.js
+++ b/test/methods/stream/display-name-prompt.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
-import * as fixtures from '../../helpers/fixtures';
-import Stream from '../../../src/js/stream';
+import * as fixtures from '../../helpers/fixtures.js';
+import Stream from '../../../src/js/stream.js';
 
 export default function displayNamePrompt () {
 	beforeEach(() => {

--- a/test/methods/stream/get-json-web-token.js
+++ b/test/methods/stream/get-json-web-token.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 import fetchMock from 'fetch-mock';
-import * as fixtures from '../../helpers/fixtures';
-import Stream from '../../../src/js/stream';
+import * as fixtures from '../../helpers/fixtures.js';
+import Stream from '../../../src/js/stream.js';
 
 
 export default function getJsonWebToken () {

--- a/test/methods/stream/init.js
+++ b/test/methods/stream/init.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
-import * as fixtures from '../../helpers/fixtures';
-import Stream from '../../../src/js/stream';
-import * as displayName from '../../../src/js/utils/display-name';
+import * as fixtures from '../../helpers/fixtures.js';
+import Stream from '../../../src/js/stream.js';
+import * as displayName from '../../../src/js/utils/display-name.js';
 
 export default function init () {
 	let validationStub;

--- a/test/methods/stream/login.js
+++ b/test/methods/stream/login.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
-import * as fixtures from '../../helpers/fixtures';
-import Stream from '../../../src/js/stream';
+import * as fixtures from '../../helpers/fixtures.js';
+import Stream from '../../../src/js/stream.js';
 
 export default function login () {
 	beforeEach(() => {

--- a/test/methods/stream/publish-event.js
+++ b/test/methods/stream/publish-event.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
-import * as fixtures from '../../helpers/fixtures';
-import Stream from '../../../src/js/stream';
+import * as fixtures from '../../helpers/fixtures.js';
+import Stream from '../../../src/js/stream.js';
 
 export default function publishEvent () {
 	beforeEach(() => {

--- a/test/methods/stream/render-comments.js
+++ b/test/methods/stream/render-comments.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* global proclaim */
-import * as fixtures from '../../helpers/fixtures';
-import Stream from '../../../src/js/stream';
+import * as fixtures from '../../helpers/fixtures.js';
+import Stream from '../../../src/js/stream.js';
 
 export default function renderComments () {
 	beforeEach(() => {

--- a/test/methods/stream/render-signed-in-message.js
+++ b/test/methods/stream/render-signed-in-message.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* global proclaim */
-import * as fixtures from '../../helpers/fixtures';
-import Stream from '../../../src/js/stream';
+import * as fixtures from '../../helpers/fixtures.js';
+import Stream from '../../../src/js/stream.js';
 
 export default function renderSignedInMessage () {
 	beforeEach(() => {

--- a/test/stream.test.js
+++ b/test/stream.test.js
@@ -1,14 +1,14 @@
 /* eslint-env mocha */
 /* global proclaim */
-import Stream from '../src/js/stream';
+import Stream from '../src/js/stream.js';
 
-import renderComments from './methods/stream/render-comments';
-import init from './methods/stream/init';
-import login from './methods/stream/login';
-import authenticateUser from './methods/stream/authenticate-user';
-import publishEvent from './methods/stream/publish-event';
-import renderSignedInMessage from './methods/stream/render-signed-in-message';
-import displayNamePrompt from './methods/stream/display-name-prompt';
+import renderComments from './methods/stream/render-comments.js';
+import init from './methods/stream/init.js';
+import login from './methods/stream/login.js';
+import authenticateUser from './methods/stream/authenticate-user.js';
+import publishEvent from './methods/stream/publish-event.js';
+import renderSignedInMessage from './methods/stream/render-signed-in-message.js';
+import displayNamePrompt from './methods/stream/display-name-prompt.js';
 
 describe("Stream", () => {
 	it("is defined", () => {

--- a/test/utils/auth.test.js
+++ b/test/utils/auth.test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 import fetchMock from 'fetch-mock';
-import * as auth from '../../src/js/utils/auth';
+import * as auth from '../../src/js/utils/auth.js';
 
 describe('Fetch JSON web token', () => {
 	afterEach(() => {

--- a/test/utils/display-name.test.js
+++ b/test/utils/display-name.test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 import fetchMock from 'fetch-mock';
-import * as displayName from '../../src/js/utils/display-name';
+import * as displayName from '../../src/js/utils/display-name.js';
 
 describe('Display name', () => {
 	describe('Validation', () => {


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing