### PR TITLE
Improve the styles for the reported state

### DIFF
--- a/src/scss/coral-talk-iframe/main.scss
+++ b/src/scss/coral-talk-iframe/main.scss
@@ -239,15 +239,13 @@
 
 // report button reported state
 .coral-comment-reportedButton {
-	background-color: oColorsByName('teal-50') !important;
+	background-color: transparent !important;
 
 	span,
 	i {
-		color: white !important;
 		padding: 3px 7px;
 		border-radius: var(--round-corners);
 		font-weight: var(--font-weight-primary-regular);
-		opacity: 0.4;
 		pointer-events: none;
 	}
 }


### PR DESCRIPTION
The styles were conflicting with Coral's styles and producing a poor experience and accessibility

**Before**
<img width="112" alt="Screenshot of the reported label before the change" src="https://user-images.githubusercontent.com/524573/99150901-74ff4f80-268f-11eb-8c18-6f3906d3cca7.png">

**After**

<img width="96" alt="Screenshot of the reported label after the change" src="https://user-images.githubusercontent.com/524573/99150913-7fb9e480-268f-11eb-846d-791cf9c8dc0d.png">
