### PR TITLE
Make getDataAttributes ignore data attributes which are not in the component's namespace

### DIFF
--- a/src/js/comments.js
+++ b/src/js/comments.js
@@ -36,8 +36,8 @@ class Comments {
 		}
 		return Object.keys(rootEl.dataset).reduce((options, key) => {
 
-			// Ignore data-o-component
-			if (key === 'oComponent') {
+			// Ignore keys which are not in the component's namespace
+			if (!key.match(/^oComments(\w)(\w+)$/)) {
 				return options;
 			}
 


### PR DESCRIPTION
This keeps the method aligned with the definition in the component template https://github.com/Financial-Times/create-origami-component/pull/214