### PR TITLE
Add support for a cachebust query parameter to the base Coral embed script URL following a bad release by Coral

### DIFF
--- a/src/js/stream.js
+++ b/src/js/stream.js
@@ -68,14 +68,13 @@ class Stream {
 		return new Promise((resolve) => {
 			try {
 				/*global Coral*/
-				const scriptElement = document.createElement('script');
-				scriptElement.src = this.useStagingEnvironment
-					? 'https://ft.staging.coral.coralproject.net/assets/js/embed.js'
-					: 'https://ft.coral.coralproject.net/assets/js/embed.js';
-
+				const cacheBuster = 'cachebust=20210806';
 				const rootUrl = this.useStagingEnvironment
 					? 'https://ft.staging.coral.coralproject.net'
 					: 'https://ft.coral.coralproject.net';
+
+				const scriptElement = document.createElement('script');
+				scriptElement.src = `${rootUrl}/assets/js/embed.js?${cacheBuster}`;
 
 				scriptElement.onload = () => {
 					this.embed = Coral.createStreamEmbed(

--- a/test/methods/stream/render-comments.js
+++ b/test/methods/stream/render-comments.js
@@ -18,7 +18,7 @@ export default function renderComments () {
 
 		stream.renderComments();
 
-		const scriptTag = document.querySelector('script[src="https://ft.coral.coralproject.net/assets/js/embed.js"]');
+		const scriptTag = document.querySelector('script[src^="https://ft.coral.coralproject.net/assets/js/embed.js"]');
 
 		proclaim.isTrue(Boolean(scriptTag));
 	});
@@ -29,7 +29,7 @@ export default function renderComments () {
 
 		stream.renderComments();
 
-		const scriptTag = document.querySelector('script[src="https://ft.staging.coral.coralproject.net/assets/js/embed.js"]');
+		const scriptTag = document.querySelector('script[src^="https://ft.staging.coral.coralproject.net/assets/js/embed.js"]');
 
 		proclaim.isTrue(Boolean(scriptTag));
 	});


### PR DESCRIPTION
Coral released a bad version of their embed.js script last week which broke commenting. They rolled it back shortly afterwards, but their script is set to be publicly cached for a week, and has no versioning in the URL we call it with. We're seeing new users still pick up the bad version and users still with broken comments after the original cache expiry date, so we're probably seeing cache chaining - adding a cachebuster seems the best way around that!

I've refactored the code a little bit to avoid defining base URLs multiple times. I've tested this version locally within the app and it appears to still load and function correctly!

Ideally I think it'd be nice to have a cachebuster that matches the o-comments version, but I don't think there's a nice way to do that...?

(I will also raise this PR against a v7 branch)