### PR TITLE
Accessibility fix: Add descriptive text to the edit display name button

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,6 @@
     "o-spacing": "^2.0.0",
     "o-typography": "^6.1.0",
     "o-editorial-typography": "^1.0.0",
-    "@financial-times/o-normalise": "^3.0.0"
+    "o-normalise": "^2.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,7 @@
     "o-forms": "^8.0.0",
     "o-spacing": "^2.0.0",
     "o-typography": "^6.1.0",
-    "o-editorial-typography": "^1.0.0"
+    "o-editorial-typography": "^1.0.0",
+    "@financial-times/o-normalise": "^3.0.0"
   }
 }

--- a/src/js/stream.js
+++ b/src/js/stream.js
@@ -213,7 +213,9 @@ class Stream {
 		signedInMessage.innerHTML = `
 									<p class="o-comments__signed-in-text">Signed in as
 										<span class="o-comments__signed-in-inner-text"></span>
-										<button id="${editButtonId}" class="o-comments__edit-display-name">Edit</button>
+										<button id="${editButtonId}" class="o-comments__edit-display-name">
+											Edit <span class="o-comments__edit-display-name-descriptive">commenting display name</span>
+										</button>
 									</p>`;
 		signedInMessage.querySelector('.o-comments__signed-in-inner-text').innerText = this.displayName;
 

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -39,6 +39,10 @@
 		margin-left: oSpacingByName('s2');
 	}
 
+	.o-comments__edit-display-name-descriptive {
+		@include oNormaliseVisuallyHidden();
+	}
+
 	.o-overlay.o-comments__displayname-prompt {
 		background: oColorsByName('paper');
 		padding: 10px;


### PR DESCRIPTION
This is the same issue as previously raised in #214 but adding the fix to v7 as well

### Issue

The edit button next to the commenting display name didn't contain enough context for users of assistive tech

### Fix

A visually hidden span has been added with the extra context needed to help all users understand the purpose of this button

### Screenshot

This shows what it read out on voiceover when the edit button has focus

<img width="852" alt="Screenshot showing voiceover on Mac with the new 'edit commenting display name' descriptive text" src="https://user-images.githubusercontent.com/524573/130592077-550096c6-fc58-493b-b983-00904c51969f.png">

### Jira ticket

[CI-742](https://financialtimes.atlassian.net/browse/CI-742)
