### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 
 # If you would like to be added as an owner, please get in touch with the Origami team at origami.support@ft.com or #origami-support on Slack
 
-* @Financial-Times/origami-core @Financial-Times/content-innovation
+* @Financial-Times/origami-core @Financial-Times/storytelling


### PR DESCRIPTION
As part of the Storytelling Team name change ([ticket](https://financialtimes.atlassian.net/browse/CI-1318)), The Github team name is updated to storytelling and [all the projects](https://biz-ops.in.ft.com/GithubTeam/Financial-Times%2Fcontent-innovation#general) with CODEOWNERS must to be updated.